### PR TITLE
update the readme for GKE examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ requested Local SSDs. Please see
 [GKE documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/local-ssd)
 for instructions for how to create a cluster with Local SSDs.
 
-Then skip to [step 4](#step-4-create-local-persistent-volume-claim).
+Then skip to [step 2](#step-2-creating-a-storageclass-19).
 
 **Note:** The raw block feature is only supported on GKE Kubernetes alpha clusters.
 


### PR DESCRIPTION
Tried to test the steps mentioned in this doc with v1.11.5-gke.5

The local ssds are mounted in the directory /mnt/disks. 

The following steps also need to be executed and not skipped to use local PVs on GKE. 
- step 2 - creation of storage class
- step 3 - creating local pv by provisioner 

Updated the text to follow through Step 2 for GKE.