### PR TITLE
Give GCP project default zone

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -106,8 +106,8 @@ Examples:
   test-infra google application credentiails and GCP ssh key pair.
 
   The first label will set `GOOGLE_APPLICATION_CREDENTIALS` environment for
-  you, and `kubetest` will acquire GCP project and zone from boskos
-  automatically. The latter will prepare SSH key pair.
+  you, and `kubetest` will acquire GCP project from boskos automatically. The
+  latter will prepare SSH key pair.
 
 EOF
 }
@@ -122,7 +122,7 @@ while getopts "h?" opt; do
 done
 
 PROVIDER=${PROVIDER:-}
-GCP_ZONE=${GCP_ZONE:-}
+GCP_ZONE=${GCP_ZONE:-us-central1-b}
 GCP_PROJECT=${GCP_PROJECT:-}
 EXTRACT_STRATEGY=${EXTRACT_STRATEGY:-ci/latest}
 DEPLOYMENT=${DEPLOYMENT:-}


### PR DESCRIPTION
fixes https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-sig-storage-local-static-provisioner-master-gke-default/1

my mistake, GCE script in k/k [has specified default zone](https://github.com/kubernetes/kubernetes/blob/ee9331e58527d317823e632d60b652ec49a146cb/cluster/gce/config-default.sh#L26), so it works without specifying GCP_ZONE 