### PR TITLE
Adding missing appVersion

### DIFF
--- a/helm/provisioner/Chart.yaml
+++ b/helm/provisioner/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 version: 2.3.0
 description: local provisioner chart 
 name: provisioner
+appVersion: 2.3.0
 keywords:
   - storage
   - local


### PR DESCRIPTION
This PR is to bring in a missing field in the Chart.yaml. The Helm CLI currently displays the provisioner chart without an `APP VERSION` field value. I understand this is nit picky, but you know... OCD.

```
NAME                 	CHART VERSION	APP VERSION	DESCRIPTION
provisioner	        2.3.0        	           	local provisioner chart
```