### PR TITLE
Support for PodSecurityPolicies

### DIFF
--- a/helm/generated_examples/baremetal-cleanbyjobs.yaml
+++ b/helm/generated_examples/baremetal-cleanbyjobs.yaml
@@ -189,3 +189,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-namespace.yaml
+++ b/helm/generated_examples/baremetal-namespace.yaml
@@ -161,3 +161,7 @@ roleRef:
   name: local-storage-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-nodeselector.yaml
+++ b/helm/generated_examples/baremetal-nodeselector.yaml
@@ -156,3 +156,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-priority-critical.yaml
+++ b/helm/generated_examples/baremetal-priority-critical.yaml
@@ -155,3 +155,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-priority-noncritical.yaml
+++ b/helm/generated_examples/baremetal-priority-noncritical.yaml
@@ -155,3 +155,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-prometheus.yaml
+++ b/helm/generated_examples/baremetal-prometheus.yaml
@@ -201,3 +201,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-resyncperiod.yaml
+++ b/helm/generated_examples/baremetal-resyncperiod.yaml
@@ -154,3 +154,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -157,3 +157,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-with-resource-limits.yaml
+++ b/helm/generated_examples/baremetal-with-resource-limits.yaml
@@ -161,3 +161,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/baremetal-without-rbac.yaml
+++ b/helm/generated_examples/baremetal-without-rbac.yaml
@@ -91,6 +91,10 @@ reclaimPolicy: Delete
 
 
 ---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+
+---
 # Source: provisioner/templates/provisioner-cluster-role-binding.yaml
 
 

--- a/helm/generated_examples/baremetal.yaml
+++ b/helm/generated_examples/baremetal.yaml
@@ -154,3 +154,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/gce-pre1.9.yaml
+++ b/helm/generated_examples/gce-pre1.9.yaml
@@ -152,3 +152,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/gce-retain.yaml
+++ b/helm/generated_examples/gce-retain.yaml
@@ -172,3 +172,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/gce.yaml
+++ b/helm/generated_examples/gce.yaml
@@ -172,3 +172,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/generated_examples/gke.yaml
+++ b/helm/generated_examples/gke.yaml
@@ -151,3 +151,7 @@ roleRef:
 # Source: provisioner/templates/namespace.yaml
 
 
+---
+# Source: provisioner/templates/pod-security-policy.yaml
+
+

--- a/helm/provisioner/templates/pod-security-policy.yaml
+++ b/helm/provisioner/templates/pod-security-policy.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.common.podSecurityPolicy -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: local-storage-provisioner-pod-security-policy
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+spec:
+  allowedHostPaths:
+  - pathPrefix: /dev
+  {{- range $classConfig := .Values.classes }}
+  - pathPrefix: {{ $classConfig.hostDir }}
+  {{- end }}
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - hostPath
+{{- end }}

--- a/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
+++ b/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
@@ -82,4 +82,43 @@ roleRef:
   name: local-storage-provisioner-jobs-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+{{- if .Values.common.podSecurityPolicy }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-storage-provisioner-psp-role
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+rules:
+- apiGroups:
+    - policy
+  resources:
+    - podsecuritypolicies
+  resourceNames:
+    - local-storage-provisioner-pod-security-policy
+  verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-storage-provisioner-psp-rolebinding
+  namespace: {{ .Values.common.namespace }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.daemonset.serviceAccount }}
+  namespace: {{ .Values.common.namespace }}
+roleRef:
+  kind: Role
+  name: local-storage-provisioner-psp-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -37,6 +37,10 @@ common:
   # Defines the name of configmap used by Provisioner
   #
   configMapName: "local-provisioner-config"
+  #
+  # Enables or disables Pod Security Policy creation and binding
+  #
+  podSecurityPolicy: false
 #
 # Configure storage classes.
 #


### PR DESCRIPTION
Add a PodSecurityPolicy, Role and RoleBinding to allow the provisioner's security contexts on clusters where PodSecurityPolicy admission control is in effect.

Fixes #72