### PR TITLE
Unset DOCKER_CONFIG in hack/run-e2e.sh

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -84,6 +84,7 @@ if [ "$KUBERNETES_PROVIDER" == "gce" -o "$KUBERNETES_CONFORMANCE_PROVIDER" == "g
     PROVISIONER_IMAGE_NAME=gcr.io/$PROJECT/local-volume-provisioner:$VERSION
     echo "Tag and push image $PROVISIONER_IMAGE_NAME"
     docker tag $PROVISIONER_E2E_IMAGE $PROVISIONER_IMAGE_NAME
+    unset DOCKER_CONFIG # We don't need this and it may be read-only and fail the command to fail
     gcloud auth configure-docker
     docker push $PROVISIONER_IMAGE_NAME
     PROVISIONER_IMAGE_PULL_POLICY=Always


### PR DESCRIPTION
Unset DOCKER_CONFIG  because we don't need it and it may be read-only which will cause the script to fail