### PR TITLE
Make pod security policy in Helm chart valid

### DIFF
--- a/helm/provisioner/templates/pod-security-policy.yaml
+++ b/helm/provisioner/templates/pod-security-policy.yaml
@@ -8,12 +8,12 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name }}
 spec:
+  allowPrivilegeEscalation: true
   allowedHostPaths:
   - pathPrefix: /dev
   {{- range $classConfig := .Values.classes }}
   - pathPrefix: {{ $classConfig.hostDir }}
   {{- end }}
-  allowPrivilegeEscalation: false
   fsGroup:
     rule: RunAsAny
   privileged: true


### PR DESCRIPTION
The earlier PR #73 contained an invalid PodSecurityPolicy. Oops.