### PR TITLE
bug fix: Copy docker config to a writable directory

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -82,6 +82,15 @@ SKIP_BUILD=${SKIP_BUILD:-}
 ALL_ARCH="amd64 arm arm64 ppc64le s390x"
 IMAGE="$REGISTRY/local-volume-provisioner"
 
+# In prow job, DOCKER_CONFIG is mounted read-only, but docker manifest command
+# expects it is writable.
+if [ -n "$DOCKER_CONFIG" ]; then
+    tmpDir=$(mktemp -d)
+    echo "info: copy $DOCKER_CONFIG/config.json to $tmpDir and set DOCKER_CONFIG to $tmpDir"
+    cp -r $DOCKER_CONFIG/config.json $tmpDir/
+    DOCKER_CONFIG=$tmpDir
+fi
+
 # remove trailing `/` if present
 REGISTRY=${REGISTRY%/}
 


### PR DESCRIPTION
In prow job, DOCKER_CONFIG is mounted read-only, [but docker manifest command expects it is writable](https://github.com/docker/cli/blob/69e1743e3d05e487ad8fc6d665b75f5b5d28b76c/cli/manifest/store/store.go#L130-L146).

### Problem

from https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-sig-storage-local-static-provisioner-build-canary/1130675800215916544

```
info: create multi-arch manifest for quay.io/external_storage/local-volume-provisioner:canary
mkdir /etc/pusher-docker-config/manifests: read-only file system
Makefile:58: recipe for target 'release' failed
make: *** [release] Error 1
```