### PR TITLE
Files are symbolic links in secret volume of the container

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -87,7 +87,7 @@ IMAGE="$REGISTRY/local-volume-provisioner"
 if [ -n "$DOCKER_CONFIG" ]; then
     tmpDir=$(mktemp -d)
     echo "info: copy $DOCKER_CONFIG/config.json to $tmpDir and set DOCKER_CONFIG to $tmpDir"
-    cp -r $DOCKER_CONFIG/config.json $tmpDir/
+    cp -L $DOCKER_CONFIG/config.json $tmpDir/
     DOCKER_CONFIG=$tmpDir
 fi
 


### PR DESCRIPTION
fixes bug of https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/104

from https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-sig-storage-local-static-provisioner-build-canary/1135731288502702080

```
info: pushing quay.io/external_storage/local-volume-provisioner-amd64:canary
error: docker config json '/tmp/tmp.xLBlhA2qcX/config.json' does not exist
Makefile:58: recipe for target 'release' failed
```