### PR TITLE
Allow user to configure additional PV labels

### DIFF
--- a/cmd/local-volume-provisioner/main.go
+++ b/cmd/local-volume-provisioner/main.go
@@ -94,6 +94,7 @@ func main() {
 		UseNodeNameOnly:   provisionerConfig.UseNodeNameOnly,
 		Namespace:         namespace,
 		JobContainerImage: jobImage,
+		LabelsForPV:       provisionerConfig.LabelsForPV,
 	})
 
 	klog.Infof("Starting metrics server at %s\n", optListenAddress)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -105,6 +105,8 @@ type UserConfig struct {
 	// UseNodeNameOnly indicates if Node.Name should be used in the provisioner name
 	// instead of Node.UID.
 	UseNodeNameOnly bool
+	// LabelsForPV stores additional labels added to provisioned PVs
+	LabelsForPV map[string]string
 }
 
 // MountConfig stores a configuration for discoverying a specific storageclass
@@ -194,6 +196,9 @@ type ProvisionerConfiguration struct {
 	// instead of Node.UID. Default is false.
 	// +optional
 	UseNodeNameOnly bool `json:"useNodeNameOnly" yaml:"useNodeNameOnly"`
+	// LabelsForPV could be used to specify additional labels that will be
+	// added to PVs created by static provisioner.
+	LabelsForPV map[string]string `json:"labelsForPV" yaml:"labelsForPV"`
 }
 
 // CreateLocalPVSpec returns a PV spec that can be used for PV creation

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -67,6 +67,11 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 		}
 	}
 
+	// Also add any additional labels configured for the PVs
+	for labelName, labelValue := range config.LabelsForPV {
+		labelMap[labelName] = labelValue
+	}
+
 	if config.UseAlphaAPI {
 		nodeAffinity, err := generateNodeAffinity(config.Node)
 		if err != nil {

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -60,10 +60,15 @@ var nodeLabelsForPV = []string{
 	common.NodeLabelKey,
 	"non-existent-label-that-pv-will-not-get"}
 
+var labelsForPV = map[string]string{
+	"local-storage-cr-name": "foobar",
+}
+
 var expectedPVLabels = map[string]string{
 	"failure-domain.beta.kubernetes.io/zone":   "west-1",
 	"failure-domain.beta.kubernetes.io/region": "west",
-	common.NodeLabelKey:                        testNodeName}
+	common.NodeLabelKey:                        testNodeName,
+	"local-storage-cr-name":                    "foobar"}
 
 var testNode = &v1.Node{
 	ObjectMeta: metav1.ObjectMeta{
@@ -364,6 +369,7 @@ func testSetup(t *testing.T, test *testConfig, useAlphaAPI bool) *Discoverer {
 		DiscoveryMap:    scMapping,
 		NodeLabelsForPV: nodeLabelsForPV,
 		UseAlphaAPI:     useAlphaAPI,
+		LabelsForPV:     labelsForPV,
 	}
 	objects := make([]runtime.Object, 0)
 	for _, o := range testStorageClasses {


### PR DESCRIPTION
Allow users to configure additional PV labels.

Fixes https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/116

