### PR TITLE
Add builtin storage class label

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1574,6 +1574,7 @@
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/uuid",
+    "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -31,7 +31,7 @@ import (
 
 	"hash/fnv"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -81,6 +81,10 @@ const (
 
 	// DefaultVolumeMode is the default volume mode of created PV object.
 	DefaultVolumeMode = "Filesystem"
+
+	// LocalStorageClassLabel is the name of local storage class label which is
+	// automatically added for local PVs.
+	LocalStorageClassLabel = "local.storage.k8s.io/storageclass"
 )
 
 // UserConfig stores all the user-defined parameters to the provisioner

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +68,7 @@ var expectedPVLabels = map[string]string{
 	"failure-domain.beta.kubernetes.io/zone":   "west-1",
 	"failure-domain.beta.kubernetes.io/region": "west",
 	common.NodeLabelKey:                        testNodeName,
+	common.LocalStorageClassLabel:              "sc1",
 	"local-storage-cr-name":                    "foobar"}
 
 var testNode = &v1.Node{
@@ -497,6 +498,7 @@ func verifyPVLabels(t *testing.T, pv *v1.PersistentVolume) {
 		t.Errorf("Labels not set")
 		return
 	}
+	expectedPVLabels[common.LocalStorageClassLabel] = pv.Spec.StorageClassName
 	eq := reflect.DeepEqual(pv.Labels, expectedPVLabels)
 	if !eq {
 		t.Errorf("Labels not as expected %v != %v", pv.Labels, expectedPVLabels)


### PR DESCRIPTION
fixes #52

This is useful to list PVs by storage class name, e.g. 

```
kubectl get pv -l local.storage.k8s.io/storageclass # all local pvs provisioned by provisioner
kubectl get pv -l local.storage.k8s.io/storageclass=local-ssd # all local pvs for storage class local-ssd
kubectl get pv -l local.storage.k8s.io/storageclass=local-hdd # all local pvs for storage class local-hdd
```