### PR TITLE
Set PV owner reference

### DIFF
--- a/cmd/local-volume-provisioner/main.go
+++ b/cmd/local-volume-provisioner/main.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/metrics"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/metrics/collectors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -95,6 +95,7 @@ func main() {
 		Namespace:         namespace,
 		JobContainerImage: jobImage,
 		LabelsForPV:       provisionerConfig.LabelsForPV,
+		SetPVOwnerRef:     provisionerConfig.SetPVOwnerRef,
 	})
 
 	klog.Infof("Starting metrics server at %s\n", optListenAddress)

--- a/helm/README.md
+++ b/helm/README.md
@@ -35,7 +35,7 @@ And there are [a lot of examples](TODO) to help you get started quickly.
 
 Helm templating is used to generate the provisioner's DaemonSet, ConfigMap and
 other necessary objects' specs.  The generated specs can be further customized
-as needed (usually not necessary), and then deployed using kubectl. 
+as needed (usually not necessary), and then deployed using kubectl.
 
 **helm template** uses 3 sources of information:
 
@@ -100,6 +100,7 @@ provisioner chart and their default values.
 | common.minResyncPeriod                       | Resync period in reflectors will be random between `minResyncPeriod` and `2*minResyncPeriod`.         | str      | `5m0s`                                                     |
 | common.configMapName                         | Provisioner ConfigMap name.                                                                           | str      | `local-provisioner-config`                                 |
 | common.podSecurityPolicy                     | Whether to create pod security policy or not.                                                         | bool     | `false`                                                    |
+| common.setPVOwnerRef                         | If set to true, PVs are set to be dependents of the owner Node.                                       | bool     | `false`                                                    |
 | classes.[n].name                             | StorageClass name.                                                                                    | str      | `-`                                                        |
 | classes.[n].hostDir                          | Path on the host where local volumes of this storage class are mounted under.                         | str      | `-`                                                        |
 | classes.[n].mountDir                         | Optionally specify mount path of local volumes. By default, we use same path as hostDir in container. | str      | `-`                                                        |

--- a/helm/provisioner/templates/provisioner.yaml
+++ b/helm/provisioner/templates/provisioner.yaml
@@ -17,6 +17,9 @@ data:
 {{- if .Values.common.useAlphaAPI }}
   useAlphaAPI: "true"
 {{- end }}
+{{- if .Values.common.setPVOwnerRef }}
+  setPVOwnerRef: "true"
+{{- end }}
 {{- if .Values.common.useJobForCleaning }}
   useJobForCleaning: "yes"
 {{- end}}

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -12,12 +12,17 @@ common:
   namespace: default
   #
   # Defines whether to create provisioner namespace
-  # 
+  #
   createNamespace: false
+  #
   # Beta PV.NodeAffinity field is used by default. If running against pre-1.10
   # k8s version, the `useAlphaAPI` flag must be enabled in the configMap.
   #
   useAlphaAPI: false
+  #
+  # Indicates if PVs should be dependents of the owner Node.
+  #
+  setPVOwnerRef: false
   #
   # Provisioner clean volumes in process by default. If set to true, provisioner
   # will use Jobs to clean.
@@ -78,7 +83,7 @@ classes:
     # reclaimPolicy: Delete # Available reclaim policies: Delete/Retain, defaults: Delete.
 #
 # Configure DaemonSet for provisioner.
-# 
+#
 daemonset:
   #
   # Defines the name of a Provisioner

--- a/pkg/deleter/deleter_test.go
+++ b/pkg/deleter/deleter_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 
 	batch_v1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -42,6 +42,8 @@ import (
 const (
 	testHostDir      = "/mnt/disks"
 	testMountDir     = "/discoveryPath"
+	testNodeName     = "somehost.acme.com"
+	testNodeUID      = "d9607e19-f88f-11e6-a518-42010a800195"
 	testStorageClass = "sc1"
 )
 
@@ -558,6 +560,11 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 			Name:         pvName,
 			HostPath:     fakePath,
 			StorageClass: testStorageClass,
+			OwnerReference: &meta_v1.OwnerReference{
+				Kind: "Node",
+				Name: testNodeName,
+				UID:  testNodeUID,
+			},
 		}
 		// If volume mode has been explicitly specified in the volume config, then explicitly set it in the PV.
 		switch vol.VolumeMode {
@@ -598,7 +605,10 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 				BlockCleanerCommand: cleanupCmd,
 			},
 		},
-		Node:              &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: "somehost.acme.com"}},
+		Node: &v1.Node{ObjectMeta: meta_v1.ObjectMeta{
+			Name: testNodeName,
+			UID:  testNodeUID,
+		}},
 		UseJobForCleaning: useJobForCleaning,
 		JobContainerImage: containerImage,
 		Namespace:         ns,


### PR DESCRIPTION
When a `PV` is created it is set to be dependent of the `Node` backing it.
When the `Node` is deleted the `PV` is also deleted by the k8s garbage collector.