### PR TITLE
controller/discoverer: add readiness check

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -919,7 +919,7 @@
   version = "kubernetes-1.14.0"
 
 [[projects]]
-  digest = "1:34093094960df1db1c921bea4dc054663f4bce54cf41de5c240f0864e23140c7"
+  digest = "1:1967352ea3ad2426f023b6366bc965ec6581039cbf54088865d678b23c3e8425"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/apis/audit",
@@ -932,6 +932,7 @@
     "pkg/authentication/user",
     "pkg/authorization/authorizer",
     "pkg/features",
+    "pkg/server/healthz",
     "pkg/storage",
     "pkg/storage/etcd",
     "pkg/util/feature",
@@ -1575,6 +1576,7 @@
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apiserver/pkg/server/healthz",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",

--- a/cmd/local-volume-provisioner/main.go
+++ b/cmd/local-volume-provisioner/main.go
@@ -48,7 +48,7 @@ var (
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 	klog.InitFlags(nil)
-	flag.StringVar(&optListenAddress, "listen-address", ":8080", "address on which to expose metrics")
+	flag.StringVar(&optListenAddress, "listen-address", ":8080", "address on which to expose metrics and readiness status")
 	flag.StringVar(&optMetricsPath, "metrics-path", "/metrics", "path under which to expose metrics")
 	flag.Parse()
 	flag.Set("logtostderr", "true")

--- a/docs/provisioner.md
+++ b/docs/provisioner.md
@@ -43,10 +43,14 @@ The basic components of the provisioner are as follows:
   The discovery and deleter run serially to simplify synchronization with the cache
   and create/delete operations.
 
-## Prometheus Metrics
+## Monitoring
 
-The metrics are exported through the Prometheus golang client on the HTTP
-endpoint `/metrics` on the listening port (default 8080).
+A dedicated HTTP server (default listening on 0.0.0.0:8080) exposes metrics and
+readiness state. 
+
+### Metrics
+
+The metrics are exported through the Prometheus golang client on the path `/metrics`.
 
 | Metric name                                                   | Metric type | Labels                                                                                                                                                                             |
 | ----------                                                    | ----------- | -----------                                                                                                                                                                        |
@@ -61,3 +65,11 @@ endpoint `/metrics` on the listening port (default 8080).
 | local_volume_provisioner_proctable_running                    | Gauge       |                                                                                                                                                                                    |
 | local_volume_provisioner_proctable_failed                     | Gauge       |                                                                                                                                                                                    |
 | local_volume_provisioner_proctable_succeeded                  | Gauge       |                                                                                                                                                                                    |
+
+### Readiness
+
+The readiness state is exposed on the path `/ready`.
+
+The state become ready when discovered local volumes are successfully created.
+
+Note that if there is no disk to create, the state will be marked as ready.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 	"math/rand"
+	"net/http"
 	"time"
 
 	"k8s.io/klog"
@@ -32,6 +33,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -90,6 +92,7 @@ func StartLocalController(client *kubernetes.Clientset, ptable deleter.ProcTable
 	if err != nil {
 		klog.Fatalf("Error initializing discoverer: %v", err)
 	}
+	healthz.InstallPathHandler(http.DefaultServeMux, "/ready", discoverer.Readyz)
 
 	deleter := deleter.NewDeleter(runtimeConfig, cleanupTracker)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -268,7 +268,7 @@ var _ = utils.SIGDescribe("PersistentVolumes-local ", func() {
 			Expect(err).NotTo(HaveOccurred(),
 				"Error getting logs from pod %s in namespace %s", provisionerPodName, config.ns)
 
-			expectedLogMessage := "Path \"/mnt/local-storage/notbindmount\" is not an actual mountpoint"
+			expectedLogMessage := "path \"/mnt/local-storage/notbindmount\" is not an actual mountpoint"
 			Expect(strings.Contains(logs, expectedLogMessage)).To(BeTrue())
 		})
 	})

--- a/vendor/k8s.io/apiserver/pkg/server/healthz/doc.go
+++ b/vendor/k8s.io/apiserver/pkg/server/healthz/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package healthz implements basic http server health checking.
+// Usage:
+//   import "k8s.io/apiserver/pkg/server/healthz"
+//   healthz.DefaultHealthz()
+package healthz // import "k8s.io/apiserver/pkg/server/healthz"

--- a/vendor/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/vendor/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// HealthzChecker is a named healthz checker.
+type HealthzChecker interface {
+	Name() string
+	Check(req *http.Request) error
+}
+
+var defaultHealthz = sync.Once{}
+
+// DefaultHealthz installs the default healthz check to the http.DefaultServeMux.
+func DefaultHealthz(checks ...HealthzChecker) {
+	defaultHealthz.Do(func() {
+		InstallHandler(http.DefaultServeMux, checks...)
+	})
+}
+
+// PingHealthz returns true automatically when checked
+var PingHealthz HealthzChecker = ping{}
+
+// ping implements the simplest possible healthz checker.
+type ping struct{}
+
+func (ping) Name() string {
+	return "ping"
+}
+
+// PingHealthz is a health check that returns true.
+func (ping) Check(_ *http.Request) error {
+	return nil
+}
+
+// LogHealthz returns true if logging is not blocked
+var LogHealthz HealthzChecker = &log{}
+
+type log struct {
+	startOnce    sync.Once
+	lastVerified atomic.Value
+}
+
+func (l *log) Name() string {
+	return "log"
+}
+
+func (l *log) Check(_ *http.Request) error {
+	l.startOnce.Do(func() {
+		l.lastVerified.Store(time.Now())
+		go wait.Forever(func() {
+			klog.Flush()
+			l.lastVerified.Store(time.Now())
+		}, time.Minute)
+	})
+
+	lastVerified := l.lastVerified.Load().(time.Time)
+	if time.Since(lastVerified) < (2 * time.Minute) {
+		return nil
+	}
+	return fmt.Errorf("logging blocked")
+}
+
+// NamedCheck returns a healthz checker for the given name and function.
+func NamedCheck(name string, check func(r *http.Request) error) HealthzChecker {
+	return &healthzCheck{name, check}
+}
+
+// InstallHandler registers handlers for health checking on the path
+// "/healthz" to mux. *All handlers* for mux must be specified in
+// exactly one call to InstallHandler. Calling InstallHandler more
+// than once for the same mux will result in a panic.
+func InstallHandler(mux mux, checks ...HealthzChecker) {
+	InstallPathHandler(mux, "/healthz", checks...)
+}
+
+// InstallPathHandler registers handlers for health checking on
+// a specific path to mux. *All handlers* for the path must be
+// specified in exactly one call to InstallPathHandler. Calling
+// InstallPathHandler more than once for the same path and mux will
+// result in a panic.
+func InstallPathHandler(mux mux, path string, checks ...HealthzChecker) {
+	if len(checks) == 0 {
+		klog.V(5).Info("No default health checks specified. Installing the ping handler.")
+		checks = []HealthzChecker{PingHealthz}
+	}
+
+	klog.V(5).Info("Installing healthz checkers:", formatQuoted(checkerNames(checks...)...))
+
+	mux.Handle(path, handleRootHealthz(checks...))
+	for _, check := range checks {
+		mux.Handle(fmt.Sprintf("%s/%v", path, check.Name()), adaptCheckToHandler(check.Check))
+	}
+}
+
+// mux is an interface describing the methods InstallHandler requires.
+type mux interface {
+	Handle(pattern string, handler http.Handler)
+}
+
+// healthzCheck implements HealthzChecker on an arbitrary name and check function.
+type healthzCheck struct {
+	name  string
+	check func(r *http.Request) error
+}
+
+var _ HealthzChecker = &healthzCheck{}
+
+func (c *healthzCheck) Name() string {
+	return c.name
+}
+
+func (c *healthzCheck) Check(r *http.Request) error {
+	return c.check(r)
+}
+
+// getExcludedChecks extracts the health check names to be excluded from the query param
+func getExcludedChecks(r *http.Request) sets.String {
+	checks, found := r.URL.Query()["exclude"]
+	if found {
+		return sets.NewString(checks...)
+	}
+	return sets.NewString()
+}
+
+// handleRootHealthz returns an http.HandlerFunc that serves the provided checks.
+func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failed := false
+		excluded := getExcludedChecks(r)
+		var verboseOut bytes.Buffer
+		for _, check := range checks {
+			// no-op the check if we've specified we want to exclude the check
+			if excluded.Has(check.Name()) {
+				excluded.Delete(check.Name())
+				fmt.Fprintf(&verboseOut, "[+]%v excluded: ok\n", check.Name())
+				continue
+			}
+			if err := check.Check(r); err != nil {
+				// don't include the error since this endpoint is public.  If someone wants more detail
+				// they should have explicit permission to the detailed checks.
+				klog.V(4).Infof("healthz check %v failed: %v", check.Name(), err)
+				fmt.Fprintf(&verboseOut, "[-]%v failed: reason withheld\n", check.Name())
+				failed = true
+			} else {
+				fmt.Fprintf(&verboseOut, "[+]%v ok\n", check.Name())
+			}
+		}
+		if excluded.Len() > 0 {
+			fmt.Fprintf(&verboseOut, "warn: some health checks cannot be excluded: no matches for %v\n", formatQuoted(excluded.List()...))
+			klog.Warningf("cannot exclude some health checks, no health checks are installed matching %v",
+				formatQuoted(excluded.List()...))
+		}
+		// always be verbose on failure
+		if failed {
+			http.Error(w, fmt.Sprintf("%vhealthz check failed", verboseOut.String()), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		if _, found := r.URL.Query()["verbose"]; !found {
+			fmt.Fprint(w, "ok")
+			return
+		}
+
+		verboseOut.WriteTo(w)
+		fmt.Fprint(w, "healthz check passed\n")
+	})
+}
+
+// adaptCheckToHandler returns an http.HandlerFunc that serves the provided checks.
+func adaptCheckToHandler(c func(r *http.Request) error) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := c(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("internal server error: %v", err), http.StatusInternalServerError)
+		} else {
+			fmt.Fprint(w, "ok")
+		}
+	})
+}
+
+// checkerNames returns the names of the checks in the same order as passed in.
+func checkerNames(checks ...HealthzChecker) []string {
+	// accumulate the names of checks for printing them out.
+	checkerNames := make([]string, 0, len(checks))
+	for _, check := range checks {
+		checkerNames = append(checkerNames, check.Name())
+	}
+	return checkerNames
+}
+
+// formatQuoted returns a formatted string of the health check names,
+// preserving the order passed in.
+func formatQuoted(names ...string) string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+	return strings.Join(quoted, ",")
+}


### PR DESCRIPTION
This PR allows to establish a healthcheck over a local volume provisioner pod.

This allows other controllers in the cluster to actually validate if a node has all it's system (daemonset) components up and running.

An immediate example of consumer would be the cluster-autoscaler to improve its capability with local volumes.

As a first step I added a readiness check for the `discoverer.DiscoverLocalVolumes()` call.
These checks could be easily be extended in other packages.
