### PR TITLE
Disable cross build in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
    
 SUDO = $(if $(filter 0,$(shell id -u)),,sudo)
 
-all: cross
+all: provisioner
 .PHONY: all
 
 cross: $(addprefix provisioner-,$(ALL_ARCH))


### PR DESCRIPTION
Currently, prow job image clean binfmt_misc at the cleanup phrase. However, `/proc/sys/fs/binfmt_misc` on the host is shared by all the docker containers, the running job will fail if another job disabled binfmt_misc.

I've opened [a feature request issue](https://github.com/kubernetes/test-infra/pull/8139) in test-infra.