### PR TITLE
clone test-infra repository to build kubetest

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -115,7 +115,7 @@ TEST_ARGS=(
     test
     -timeout=60m
     -v
-    sigs.k8s.io/sig-storage-local-static-provisioner/test/e2e
+    ./test/e2e
 )
 
 if [ -n "$KUBECTL" ]; then


### PR DESCRIPTION
fix CI issues, see https://prow.k8s.io/?job=ci-sig-storage-local-static-provisioner-master-gce-latest

why: cannot use `go get -u k8s.io/test-infra/kubetest` to build `kubetest` now and it's hard to fix it soon. because `replace` directives are used in test-infra, the best practice is to clone the repository and build the binary in the project.

xref: https://github.com/kubernetes/test-infra/issues/14712