### PR TITLE
Remove old cleanup status before create new pv

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -307,6 +307,13 @@ func (d *Discoverer) discoverVolumesAtPath(class string, config common.MountConf
 			continue
 		}
 
+		// remove old cleanup status
+		_, _, err = d.CleanupTracker.RemoveStatus(pvName, usejob)
+		if err != nil {
+			klog.Errorf("expected status exists and fail to remove cleanup status for pv %s", pvName)
+			continue
+		}
+
 		mountOptions, err := d.getMountOptionsFromStorageClass(class)
 		if err != nil {
 			discoErrors = append(discoErrors, fmt.Errorf("failed to get mount options from storage class %s: %v", class, err))


### PR DESCRIPTION
**Ⅰ. Describe what this PR does**

fix a bug, the bug will make that pv created has dirty data.

**II. How to reproduce the BUG**

At first, privisioner  will loop check pv every 10 seconds, then I describe the steps by timeline.

00:00 provisioner find a pvX with "Released" status, put the pvX cleanup status to Table, and mark it "Running"

00:01 the async task completes cleanup work quickly, and mark it "Succeed"

**00:02~00:09 pvX is deleted by some people or itself, and provisioner cache removes the pv. BUT the cleanup status of pvX stays in the Table(ProcTableImpl)**

00:10 provisioner recreate the pvX

some hours laster, the status of pvX becomes "Released"

10:00 provisioner find pvX "Released", and try to get cleanup status of pvX from Table. Unfortunately, provisioner find the "Succeed" from "00:02~00:09", then just delete pv without cleanuping  So the data leaks. 

Other cases also can recreate it. For example, when apiserver has problems, provisioner delete a pv successfully, but provisioner watch the delete event after some seconds, maybe more than 10 seconds. 

**III. How fix** 

I just clear the cleanup status when the pv recreated. 
