### PR TITLE
feat: add namePattern field in discovery PV

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -81,6 +81,9 @@ const (
 
 	// DefaultVolumeMode is the default volume mode of created PV object.
 	DefaultVolumeMode = "Filesystem"
+
+	// DefaultNamePattern is the default name pattern of in PV discovery.
+	DefaultNamePattern = "*"
 )
 
 // UserConfig stores all the user-defined parameters to the provisioner
@@ -127,6 +130,9 @@ type MountConfig struct {
 	// and desire volume mode is Filesystem.
 	// Must be a filesystem type supported by the host operating system.
 	FsType string `json:"fsType" yaml:"fsType"`
+	// NamePattern name pattern check
+	// only discover file name matching pattern("*" by default)
+	NamePattern string `json:"namePattern" yaml:"namePattern"`
 }
 
 // RuntimeConfig stores all the objects that the provisioner needs to run
@@ -325,19 +331,24 @@ func ConfigMapDataToVolumeConfig(data map[string]string, provisionerConfig *Prov
 		if config.VolumeMode == "" {
 			config.VolumeMode = DefaultVolumeMode
 		}
+
+		if config.NamePattern == "" {
+			config.NamePattern = DefaultNamePattern
+		}
 		volumeMode := v1.PersistentVolumeMode(config.VolumeMode)
 		if volumeMode != v1.PersistentVolumeBlock && volumeMode != v1.PersistentVolumeFilesystem {
 			return fmt.Errorf("unsupported volume mode %s", config.VolumeMode)
 		}
 
 		provisionerConfig.StorageClassConfig[class] = config
-		klog.Infof("StorageClass %q configured with MountDir %q, HostDir %q, VolumeMode %q, FsType %q, BlockCleanerCommand %q",
+		klog.Infof("StorageClass %q configured with MountDir %q, HostDir %q, VolumeMode %q, FsType %q, BlockCleanerCommand %q, NamePattern %q",
 			class,
 			config.MountDir,
 			config.HostDir,
 			config.VolumeMode,
 			config.FsType,
-			config.BlockCleanerCommand)
+			config.BlockCleanerCommand,
+			config.NamePattern)
 	}
 	return nil
 }

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -109,6 +109,7 @@ func TestLoadProvisionerConfigs(t *testing.T) {
      - "2"
    volumeMode: Filesystem
    fsType: ext4
+   namePattern: nvm*
 `,
 				"useAlphaAPI":     "true",
 				"minResyncPeriod": "1h30m",
@@ -121,6 +122,7 @@ func TestLoadProvisionerConfigs(t *testing.T) {
 						BlockCleanerCommand: []string{"/scripts/shred.sh", "2"},
 						VolumeMode:          "Filesystem",
 						FsType:              "ext4",
+						NamePattern:         "nvm*",
 					},
 				},
 				UseAlphaAPI: true,

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -278,6 +278,16 @@ func (d *Discoverer) discoverVolumesAtPath(class string, config common.MountConf
 	var discoErrors []error
 	var totalCapacityBlockBytes, totalCapacityFSBytes int64
 	for _, file := range files {
+		if config.NamePattern != "" {
+			matched, err := filepath.Match(config.NamePattern, file)
+			if err != nil {
+				return err
+			}
+			if !matched {
+				klog.Infof("file(%s) under(%s) does not match pattern(%s)", file, config.MountDir, config.NamePattern)
+				continue
+			}
+		}
 		startTime := time.Now()
 		filePath := filepath.Join(config.MountDir, file)
 		volMode, err := common.GetVolumeMode(d.VolUtil, filePath)


### PR DESCRIPTION
This PR is to add a `namePattern ` field, with following config, only `/dev/nvm*` device names would be discovered, by default `namePattern ` field is empty, it won't do any matching, so it's backward compatible.

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: local-provisioner-config
  namespace: default
data:
  storageClassMap: |
    fast-disks:
       hostDir: /dev
       mountDir:  /dev
       blockCleanerCommand:
         - "/scripts/shred.sh"
         - "2"
       volumeMode: Filesystem
       fsType: ext4
       namePattern: "nvme*"
```

/assign @cofyc