### PR TITLE
Fix blkdiscard script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ helm chart refactoring:
 - **Action required**\
   As the helm-chart structure changed the already running pod will be recreated during upgrade. Documentation can be found under [helm/README.md](./helm/README.md). Compare your existing values with the new chart parameter before upgrade.  [#171](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/171)
 
+- blkdiscard.sh no longer zeros disks.
+  This script was passing the -z option to blkdiscard which meant it was not
+  performing discards. This has been fixed. If you desire zeroing, rather than
+  block discarding, please switch to dd_zero.sh.
+
 # [v2.3.4](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/releases/tag/v2.3.4)
 
 Image updates:

--- a/deployment/docker/scripts/blkdiscard.sh
+++ b/deployment/docker/scripts/blkdiscard.sh
@@ -31,4 +31,4 @@ fi
 validateBlockDevice
 
 echo "Calling blkdiscard"
-/sbin/blkdiscard -vz $LOCAL_PV_BLKDEVICE
+/sbin/blkdiscard -v $LOCAL_PV_BLKDEVICE


### PR DESCRIPTION
blkdiscard with -z is precisely equivalent to the dd_zero script: rather
than discarding sectors, they are written to, causing more writes to the
drive, and taking a long time.

Quoting the man page:
"""
       -z, --zeroout
              Zero-fill rather than discard.
"""

Signed-off-by: Robert Collins <robert.collins@cognite.com>


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR makes the blkdiscard script actually discard blocks on SSD/NVMe drives, rather than writing \00's.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```

```

/sig storage-local-static-provisioner