### PR TITLE
OWNERS: move dhirajh to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,5 +5,7 @@ approvers:
   - saad-ali
   - wongma7
   - jsafrane
-  - dhirajh
   - cofyc
+
+emeritus_approvers:
+  - dhirajh


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit moves dhirajh to the
emeritus_approvers section.

cc @dhirajh @mrbobbytables 

/kind cleanup
/assign @cofyc 


**Release note**:
```
NONE
```
