### PR TITLE
gke: use non-default network

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -292,6 +292,7 @@ if [ "$PROVIDER" == "gke" ]; then
         --test exec
         -v 1
         --cluster-name "$CLUSTER"
+        --network "$CLUSTER"
         --gcp-service-account "$GOOGLE_APPLICATION_CREDENTIALS"
         --environment "$GKE_ENVIRONMENT"
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Sometimes it's possible to delete the default network:

```
Deleted [https://container.googleapis.com/v1/projects/gke-up-g1-3-c1-4-up-clu/zones/us-central1-b/clusters/e2e].
Deleted [https://www.googleapis.com/compute/v1/projects/gke-up-g1-3-c1-4-up-clu/global/networks/default].
```

However, it's not true most of the time:

```
Deleted [https://container.googleapis.com/v1/projects/k8s-jkns-gci-gke-alpha-1-4/zones/us-central1-b/clusters/e2e].
ERROR: (gcloud.compute.networks.delete) Could not fetch resource:
 - The network resource 'projects/k8s-jkns-gci-gke-alpha-1-4/global/networks/default' is already being used by 'projects/k8s-jkns-gci-gke-alpha-1-4/global/firewalls/default-umj5tqq6uvmkhu4cj6nfuktl'
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_sig-storage-local-static-provisioner/211/pull-sig-storage-local-static-provisioner-e2e-gke/1293006005185024004

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
