### PR TITLE
use container env to set log level value and listen-address of local-provisioner

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     e2fsprogs \
     bash
 
+ENV LISTEN_ADDRESS=:8080 LOG_LEVEL_VALUE=0
 COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/${OS}/${ARCH}/local-volume-provisioner /local-provisioner
 ADD deployment/docker/scripts /scripts
-ENTRYPOINT ["/local-provisioner"]
+ENTRYPOINT /local-provisioner -listen-address=$LISTEN_ADDRESS -v=$LOG_LEVEL_VALUE


### PR DESCRIPTION
use container env to set log level value and listen-address of local-provisioner

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
I hava found that I cannot specify the log level value and listen-address when using the docker image built from Makefile, which is not convenient.
I think it maybe better to use container env to set log level value and listen-address, so i can modify my daemonset.yaml to adapt different environment.
Thanks!

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #239 

**Special notes for your reviewer**:


**Release note**:
```
use container env to set log level value and listen-address of local-provisioner
```
