### PR TITLE
Duplicate volume guard

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -84,3 +84,23 @@ func (cache *VolumeCache) ListPVs() []*v1.PersistentVolume {
 	}
 	return pvs
 }
+
+// LookupPVsByPath returns a list of all of the PVs in the cache with a given local path
+// Note: The PVs in the cache have been filtered by the populator so that the cache only
+// contains volumes created by the local-static-provisioner running on this knode.
+func (cache *VolumeCache) LookupPVsByPath(filePath string) []string {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+	var matches = make([]string, 0, 1)
+
+	for _, pv := range cache.pvs {
+		lvs := pv.Spec.Local
+		if lvs != nil {
+			if lvs.Path == filePath {
+				matches = append(matches, pv.ObjectMeta.Name)
+			}
+		}
+	}
+
+	return matches
+}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -281,6 +281,39 @@ func TestDiscoverVolumes_BadVolume(t *testing.T) {
 	verifyPVsNotInCache(t, test)
 }
 
+func TestDiscoverVolumes_PathAlreadyActive(t *testing.T) {
+	vols := map[string][]*util.FakeDirEntry{
+		"dir1": {
+			{Name: "mount1", Hash: 0xaaaafef5, VolumeType: util.FakeEntryFile, Capacity: 100 * 1024},
+		},
+	}
+
+	// preload the cache with an existing volume using the path testHostDir + "/dir1/mount1"
+	localPVConfig := &common.LocalPVConfig{
+		Name:            "existing-pv",
+		HostPath:        testHostDir + "/dir1/mount1",
+		StorageClass:    "existingclass",
+		ReclaimPolicy:   reclaimPolicyDelete,
+		ProvisionerName: testProvisionerName,
+		VolumeMode:      "Filesystem",
+	}
+	lvSpec := common.CreateLocalPVSpec(localPVConfig)
+	cache := cache.NewVolumeCache()
+	cache.AddPV(lvSpec)
+
+	test := &testConfig{
+		dirLayout:       vols,
+		expectedVolumes: map[string][]*util.FakeDirEntry{},
+		cache:           cache,
+	}
+	d := testSetup(t, test, false, false)
+
+	d.DiscoverLocalVolumes()
+
+	verifyCreatedPVs(t, test)
+	verifyPVsNotInCache(t, test)
+}
+
 func TestDiscoverVolumes_CleaningInProgress(t *testing.T) {
 	vols := map[string][]*util.FakeDirEntry{
 		"dir1": {
@@ -350,7 +383,9 @@ func TestDiscoverVolumes_InvalidMode(t *testing.T) {
 }
 
 func testSetup(t *testing.T, test *testConfig, useAlphaAPI, setPVOwnerRef bool) *Discoverer {
-	test.cache = cache.NewVolumeCache()
+	if test.cache == nil {
+		test.cache = cache.NewVolumeCache()
+	}
 	test.volUtil = util.NewFakeVolumeUtil(false /*deleteShouldFail*/, map[string][]*util.FakeDirEntry{})
 	test.volUtil.AddNewDirEntries(testMountDir, test.dirLayout)
 	test.cleanupTracker = &deleter.CleanupStatusTracker{ProcTable: deleter.NewProcTable(),

--- a/pkg/populator/populator.go
+++ b/pkg/populator/populator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package populator
 
 import (
+	"strings"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 
@@ -83,6 +85,11 @@ func (p *Populator) handlePVUpdate(pv *v1.PersistentVolume) {
 		if pv.Annotations != nil {
 			provisioner, found := pv.Annotations[common.AnnProvisionedBy]
 			if !found {
+				return
+			}
+			if p.UseNodeNameOnly && strings.HasPrefix(provisioner, p.Name) {
+				// The PV was created on this node
+				p.Cache.AddPV(pv)
 				return
 			}
 			if provisioner == p.Name {

--- a/pkg/populator/populator.go
+++ b/pkg/populator/populator.go
@@ -87,14 +87,24 @@ func (p *Populator) handlePVUpdate(pv *v1.PersistentVolume) {
 			if !found {
 				return
 			}
-			if p.UseNodeNameOnly && strings.HasPrefix(provisioner, p.Name) {
-				// The PV was created on this node
-				p.Cache.AddPV(pv)
-				return
-			}
 			if provisioner == p.Name {
 				// This PV was created by this provisioner
 				p.Cache.AddPV(pv)
+				return
+			}
+			if p.UseNodeNameOnly {
+				nodeLabel, ok := pv.ObjectMeta.Labels[common.NodeNameLabel]
+				if !ok {
+					return
+				}
+				if nodeLabel != p.Node.Name {
+					return
+				}
+				if strings.HasPrefix(provisioner, p.Name+"-") {
+					// This PV was created by this provisioner with useNodeNameOnly disabled
+					klog.Infof("cacheing pv %q (useNodeNameOnly mode)", pv.Name)
+					p.Cache.AddPV(pv)
+				}
 			}
 		}
 	}

--- a/pkg/util/volume_util_unsupported.go
+++ b/pkg/util/volume_util_unsupported.go
@@ -32,3 +32,11 @@ func (u *volumeUtil) GetBlockCapacityByte(fullPath string) (int64, error) {
 func (u *volumeUtil) IsBlock(fullPath string) (bool, error) {
 	return false, fmt.Errorf("IsBlock is unsupported in this build")
 }
+
+func (u *volumeUtil) IsSymLink(fullPath string) (bool, error) {
+	return false, fmt.Errorf("IsBlock is unsupported in this build")
+}
+
+func (u *volumeUtil) IsMount(fullPath string) (bool, error) {
+	return false, fmt.Errorf("IsBlock is unsupported in this build")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The local-static-provisioner can create multiple separate kubernetes volumes pointing at the same underlying local host path through misconfiguration, e.g. if you accidentally configure different storageClasses with the same path in your configmap:

```
apiVersion: v1
kind: ConfigMap
data:
  filterPVsByNodeName: "yes"
  storageClassMap: |
    local-storage:
      hostDir: /k8svolumes
      mountDir: /k8svolumes
      blockCleanerCommand:
        - /scripts/fsclean.sh
      volumeMode: Filesystem
    local-storage-again:
      hostDir: /k8svolumes
      mountDir: /k8svolumes
      blockCleanerCommand:
        - /scripts/fsclean.sh
      volumeMode: Filesystem
```

This will result in the two volumes being created for each local path - one for each two storageClasses configured - both available and mountable by different pods. 😱

You will also get duplicates if you change the name of a configured storageClass associated with a given discovery path **after** the PVs have already been created with the old class.  Again, this could be caused by an error, or as part of a conscious attempt to reorganise storage (as was in our case).

Having duplicates of essential the **same** volume mounted in different customer pods is rarely desirable, opens up security concerns and will likely result in data loss for the pods colliding on the underlying filesystem.  A more cautious approach can be adopted without a high implementation cost.

This change aims to prevent a new volume from being created when any other **local-static-provisioner** volume already exists (of any storageClass) using the same local host path.  This will provide a sensible safe-guard against human configuration errors.  It also opens up the possibility of safer storage migrations between classes because the configuration changes can be rolled out without fear of disrupting any active volumes.  Volumes could then be migrated on a volume-by-volume basis and the new volumes will not be provisioned until the old volumes are deleted. 

**Implementation**

The provisioner already makes use of an informer cache of PVs which it uses to ensure that it does not repeatedly try and provision the same volume.  This change adds a method to the cache to return a list of names of PVs that are present on a given path and a check during the discovery will block the creation of a volume with an error message if it finds that any other volumes (of any storage class but that belong to the local provisioner) exist with the path.

The informer cache is synced before the provisioner runs discovery so we wont have a race upon start up between cache population and discovery.

If the provisioner is switched to `useNodeNameOnly: true` mode then we want it to match any pre-existing volumes that were configured with the nodename-uid annotation so that we can properly load these volumes into the cache and prevent duplicates.

**Special notes for your reviewer**:
NONE

**Release note**:

```
Users are prevented from creating new physical volumes for local static paths that are used in existing volumes.  An attempt to do so will return an error indicating the path and the existing volume which are preventing the new volume from being created.
```
