### PR TITLE
WIP: Adding callbacks to be executed before deleting released PVs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -110,7 +110,7 @@ func StartLocalController(client *kubernetes.Clientset, ptable deleter.ProcTable
 	}
 	klog.Info("Controller started\n")
 	for {
-		deleter.DeletePVs()
+		deleter.DeletePVs(func(pv *v1.PersistentVolume) error { return nil })
 		discoverer.DiscoverLocalVolumes()
 		time.Sleep(10 * time.Second)
 	}

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -67,7 +67,7 @@ func NewDeleter(config *common.RuntimeConfig, cleanupTracker *CleanupStatusTrack
 
 // DeletePVs will scan through all the existing PVs that are released, and cleanup and
 // delete them
-func (d *Deleter) DeletePVs() {
+func (d *Deleter) DeletePVs(deleteFn func(pv *v1.PersistentVolume) error) {
 	for _, pv := range d.Cache.ListPVs() {
 		if pv.Status.Phase != v1.VolumeReleased {
 			continue
@@ -82,7 +82,7 @@ func (d *Deleter) DeletePVs() {
 		case v1.PersistentVolumeReclaimDelete:
 			klog.V(4).Infof("reclaimVolume[%s]: policy is Delete", name)
 			// Cleanup volume
-			err := d.deletePV(pv)
+			err := d.deletePV(pv, deleteFn)
 			if err != nil {
 				mode, modeErr := d.getVolMode(pv)
 				if modeErr != nil {
@@ -128,7 +128,7 @@ func (d *Deleter) shouldRunJob(mode v1.PersistentVolumeMode) bool {
 	return mode == v1.PersistentVolumeBlock && d.RuntimeConfig.UseJobForCleaning
 }
 
-func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
+func (d *Deleter) deletePV(pv *v1.PersistentVolume, deleteFn func(pv *v1.PersistentVolume) error) error {
 	if pv.Spec.Local == nil {
 		return fmt.Errorf("Unsupported volume type")
 	}
@@ -142,6 +142,7 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 	if err != nil {
 		return err
 	}
+
 	volMode, err := d.getVolMode(pv)
 	if err != nil {
 		return fmt.Errorf("failed to get volume mode of path %q: %v", mountPath, err)
@@ -161,6 +162,11 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 
 	switch state {
 	case CSSucceeded:
+		klog.Errorf("%v", state)
+		err := deleteFn(pv)
+		if err != nil {
+			klog.Warningf("callback function exited with an error: %v", err)
+		}
 		// Found a completed cleaning entry
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
@@ -210,6 +216,12 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 	}
 
 	return d.runProcess(pv, volMode, mountPath, config)
+}
+
+func GetDefaultDeleteFn() func(pv *v1.PersistentVolume) error {
+	return func(pv *v1.PersistentVolume) error {
+		return nil
+	}
 }
 
 func (d *Deleter) runProcess(pv *v1.PersistentVolume, volMode v1.PersistentVolumeMode, mountPath string,

--- a/pkg/deleter/deleter_test.go
+++ b/pkg/deleter/deleter_test.go
@@ -104,7 +104,7 @@ func TestDeleteVolumes_Basic(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d, "pv4")
 	verifyDeletedPVs(t, test)
 }
@@ -122,11 +122,11 @@ func TestDeleteVolumes_Twice(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	verifyDeletedPVs(t, test)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	test.expectedDeletedPVs = map[string]string{}
 	verifyDeletedPVs(t, test)
@@ -141,7 +141,7 @@ func TestDeleteVolumes_Empty(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	verifyDeletedPVs(t, test)
 }
@@ -159,7 +159,7 @@ func TestDeleteVolumes_DeletePVFails(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	verifyDeletedPVs(t, test)
 	verifyPVExists(t, test)
@@ -178,12 +178,12 @@ func TestDeleteVolumes_DeletePVNotFound(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	verifyDeletedPVs(t, test)
 
 	// delete not found pv
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -211,11 +211,11 @@ func TestDeleteVolumes_UnsupportedReclaimPolicy(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	verifyDeletedPVs(t, test)
 
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -246,11 +246,11 @@ func TestDeleteVolumes_UnknownReclaimPolicy(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	verifyDeletedPVs(t, test)
 
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -280,7 +280,7 @@ func TestDeleteVolumes_CleanupFails(t *testing.T) {
 	}
 	d := testSetupForProcCleaning(t, test, nil)
 
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	waitForAsyncToComplete(t, d)
 	// A few checks to see if its still running.
 	if test.procTable.IsRunningCount == 0 {
@@ -310,7 +310,7 @@ func TestDeleteBlock_BasicProcessExec(t *testing.T) {
 	test := &testConfig{vols: vols, expectedDeletedPVs: expectedDeletedPVs}
 	d := testSetupForProcCleaning(t, test, []string{"sh", "-c", "echo \"hello\""})
 
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -345,7 +345,7 @@ func TestDeleteBlock_FailedProcess(t *testing.T) {
 
 	test := &testConfig{vols: vols, expectedDeletedPVs: expectedDeletedPVs}
 	d := testSetupForProcCleaning(t, test, []string{"sh", "-c", "exit 10"})
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -384,7 +384,7 @@ func TestDeleteBlock_DuplicateAttempts(t *testing.T) {
 	// Simulate a currently running process by marking it as running in process table
 	test.procTable.MarkRunning("pv4")
 
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -418,7 +418,7 @@ func TestDeleteBlock_Jobs(t *testing.T) {
 	cmd := []string{"sh", "-c", "echo \"hello\""}
 	d := testSetupForJobCleaning(t, test, cmd)
 
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -489,7 +489,7 @@ func TestDeleteBlock_DuplicateAttempts_Jobs(t *testing.T) {
 	// Simulate a currently running process by marking it as running in process table
 	test.jobControl.MarkRunning("pv4")
 
-	err := d.deletePV(test.generatedPVs["pv4"])
+	err := d.deletePV(test.generatedPVs["pv4"], GetDefaultDeleteFn())
 	if err != nil {
 		t.Error(err)
 	}
@@ -504,6 +504,29 @@ func TestDeleteBlock_DuplicateAttempts_Jobs(t *testing.T) {
 		t.Errorf("Unexpected job was created. %+v", jobs)
 		t.Fatalf("No job should have been created when one is already simulated as running.")
 	}
+}
+
+func TestDeleteFn(t *testing.T) {
+	vols := map[string]*testVol{
+		"pv4": {
+			pvPhase: v1.VolumeReleased,
+		},
+	}
+	expectedDeletedPVs := map[string]string{"pv4": ""}
+	test := &testConfig{
+		vols:               vols,
+		expectedDeletedPVs: expectedDeletedPVs,
+	}
+	d := testSetupForProcCleaning(t, test, nil)
+
+	called := false
+	deleteFn := func(*v1.PersistentVolume) error { called = true; return nil }
+	d.DeletePVs(deleteFn)
+	if !called {
+		t.Errorf("deleteFn not called")
+	}
+	waitForAsyncToComplete(t, d, "pv4")
+	verifyDeletedPVs(t, test)
 }
 
 func testSetupForProcCleaning(t *testing.T, config *testConfig, cleanupCmd []string) *Deleter {
@@ -666,7 +689,7 @@ func waitForAsyncToComplete(t *testing.T, d *Deleter, pvNames ...string) {
 	}
 
 	// Run again to delete PVs that have been cleaned up.
-	d.DeletePVs()
+	d.DeletePVs(GetDefaultDeleteFn())
 	for _, pvName := range pvNames {
 		if d.CleanupStatus.ProcTable.IsRunning(pvName) {
 			t.Errorf("Command failed to complete for pv %s", pvName)


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

feature


**What this PR does / why we need it**:
DeletePVs can take functions that will be executed after the devices are
cleaned and before the PVs are deleted.
Added function for symlink cleanup.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #255 

**Special notes for your reviewer**:


**Release note**:
```

```
