### PR TITLE
Support for restarting main sync loop on ConfigMap change

### DIFF
--- a/docs/provisioner.md
+++ b/docs/provisioner.md
@@ -51,7 +51,7 @@ The basic components of the provisioner are as follows:
 We configure local volume provisioner using ConfigMap. The explanation and
 default value of each key are as follows:
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -142,6 +142,23 @@ data:
 
 Note that, when you deploy provisioner with `helm`. You must configure
 provisioner via helm values, please refer to our [helm docs](/helm).
+
+### Updating configuration without restarting provisioner
+
+Provisioner supports reloading updated ConfigMap without needing to restart the pod.
+Please see [updating configuration](/docs/faqs.md#can-i-update-the-provisioner-configuration-without-restarting-the-provisioner)
+in the FAQ section for details. The following table summarizes the effect of each field have
+when updating provisioner configuration for "existing PVs" and "PVs to be provisioned"
+
+| Field              | Existing PVs                | PVs to be provisioned
+| -----              | ------------                | ---------------------
+| useAlphaAPI        | NO effect                   | Will apply during provisioning
+| useJobForCleaning  | Effective on clean up       | Effective on clean up
+| useNodeNameOnly    | NO effect                   | Will apply during provisioning
+| setPVOwnerRef      | NO effect                   | Will apply during provisioning
+| labelsForPV        | NO effect                   | Will apply during provisioning
+| NodeLabelsForPV    | NO effect                   | Will apply during provisioning
+| StorageClassConfig | NO effect                   | Will apply during provisioning
 
 ## Monitoring
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -53,9 +53,13 @@ However, it's safe to add a new storage class.
 
 ### How to update
 
-Currently, the provisioner does not reload configuration automatically. When
-you finish updating the ConfigMap, you must delete the pods of provisioner
-DaemonSet to take effect.
+Provisioner supports reloading updated ConfigMap without needing to
+restart the pod. Please understand all fields in provisioner
+[configuration](/docs/provisioner.md#configuration) and limitations
+around effect on existing provisioned PVs. After the ConfigMap have been
+updated, the provisioner will restart its main sync loop (including
+informer and job controller) to pick up the configuration on the
+next ConfigMap load and compare cycle.
 
 Note that if you add new discovery directory in provisioner configuration, you
 must update provisioner pod template spec too. This is not necessary if you

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -345,7 +345,7 @@ func ConfigMapDataToVolumeConfig(data map[string]string, provisionerConfig *Prov
 		}
 
 		provisionerConfig.StorageClassConfig[class] = config
-		klog.Infof("StorageClass %q configured with MountDir %q, HostDir %q, VolumeMode %q, FsType %q, BlockCleanerCommand %q, NamePattern %q",
+		klog.V(5).Infof("StorageClass %q configured with MountDir %q, HostDir %q, VolumeMode %q, FsType %q, BlockCleanerCommand %q, NamePattern %q",
 			class,
 			config.MountDir,
 			config.HostDir,
@@ -379,6 +379,23 @@ func insertSpaces(original string) string {
 		spaced += "\n"
 	}
 	return spaced
+}
+
+// UserConfigFromProvisionerConfig creates a UserConfig from the provided ProvisionerConfiguration struct
+func UserConfigFromProvisionerConfig(node *v1.Node, namespace, jobImage string, config ProvisionerConfiguration) *UserConfig {
+	return &UserConfig{
+		Node:              node,
+		DiscoveryMap:      config.StorageClassConfig,
+		NodeLabelsForPV:   config.NodeLabelsForPV,
+		UseAlphaAPI:       config.UseAlphaAPI,
+		UseJobForCleaning: config.UseJobForCleaning,
+		MinResyncPeriod:   config.MinResyncPeriod,
+		UseNodeNameOnly:   config.UseNodeNameOnly,
+		Namespace:         namespace,
+		JobContainerImage: jobImage,
+		LabelsForPV:       config.LabelsForPV,
+		SetPVOwnerRef:     config.SetPVOwnerRef,
+	}
 }
 
 // LoadProvisionerConfigs loads all configuration into a string and unmarshal it into ProvisionerConfiguration struct.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+func TestSignalStop(t *testing.T) {
+	s := newSignal()
+	defer s.close()
+
+	sync := make(chan bool)
+
+	service := func(signal *signal) {
+		for {
+			select {
+			case stopped := <-signal.closing:
+				stopped <- struct{}{}
+				sync <- true
+				return
+			}
+		}
+	}
+
+	go service(s)
+	s.stop()
+
+	if !<-sync {
+		t.Error("Expected service to be successfully stopped")
+	}
+}

--- a/pkg/util/volume_util_unsupported.go
+++ b/pkg/util/volume_util_unsupported.go
@@ -35,7 +35,7 @@ func NewVolumeUtil() (VolumeUtil, error) {
 // GetFsCapacityByte returns capacity in bytes about a mounted filesystem.
 // fullPath is the pathname of any file within the mounted filesystem. Capacity
 // returned here is total capacity.
-func (u *volumeUtil) GetFsCapacityByte(hostPath, mountPath string, mountPointMap map[string]interface{}) (int64, error) {
+func (u *volumeUtil) GetFsCapacityByte(hostPath, mountPath string) (int64, error) {
 	return 0, fmt.Errorf("GetFsCapacityByte is unsupported in this build")
 }
 
@@ -50,7 +50,7 @@ func (u *volumeUtil) IsBlock(fullPath string) (bool, error) {
 	return false, fmt.Errorf("IsBlock is unsupported in this build")
 }
 
-func (u *volumeUtil) IsLikelyMountPoint(hostPath, mountPath, file string) (bool, error) {
+func (u *volumeUtil) IsLikelyMountPoint(hostPath, mountPath string, mountPointMap map[string]interface{}) (bool, error) {
 	return false, fmt.Errorf("IsLikelyMountPoint is unsupported in this build")
 }
 

--- a/pkg/watcher/config.go
+++ b/pkg/watcher/config.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watcher
+
+import (
+	"reflect"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+)
+
+// ConfigWatcher monitors the config file periodically with the provided interval
+// and compares the provisioner config that is currently applied and the loaded provisioner
+// config. If a difference between the configs is detected, it will signal to the sync loop
+// to restart.
+type ConfigWatcher struct {
+	configPath        string
+	resyncPeriod      time.Duration
+	lastAppliedConfig common.ProvisionerConfiguration
+}
+
+// NewConfigWatcher creates a new ConfigWatcher object with the provided
+// path of the config file, period to run the load and compare, and the initial
+// configuration that is currently being applied for the provisioner.
+func NewConfigWatcher(configPath string, resyncPeriod time.Duration, config common.ProvisionerConfiguration) *ConfigWatcher {
+	return &ConfigWatcher{
+		configPath:        configPath,
+		resyncPeriod:      resyncPeriod,
+		lastAppliedConfig: config,
+	}
+}
+
+// Run will start running the ConfigWatcher in a loop. During each reload cycle,
+// it loads the configuration from the config file on disk and compares with the last applied
+// configuration. If there is a difference, it will send the loaded configuration to the
+// channel indicating restart sync loop is needed and then update its last applied configuration.
+func (cw *ConfigWatcher) Run(configUpdate chan<- common.ProvisionerConfiguration) {
+	provisionerConfig := common.ProvisionerConfiguration{
+		StorageClassConfig: make(map[string]common.MountConfig),
+		MinResyncPeriod:    metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	for {
+		select {
+		case <-time.After(cw.resyncPeriod):
+			if err := common.LoadProvisionerConfigs(cw.configPath, &provisionerConfig); err != nil {
+				klog.Fatalf("Error parsing Provisioner's configuration: %#v. Exiting...\n", err)
+			}
+
+			if !reflect.DeepEqual(cw.lastAppliedConfig, provisionerConfig) {
+				klog.Infof("Loaded and detected updated configuration: %+v", provisionerConfig)
+				klog.Infof("Signalling sync loop to restart to pick up updated configuration...")
+
+				configUpdate <- provisionerConfig
+				cw.lastAppliedConfig = provisionerConfig
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This change adds support for restarting the main sync loop
when a config change has been detected on disk from change
in the ConfigMap.

The implementation adds a ConfigWatcher go routine which will
check the if the config has been updated by loading from disk
and comparing with what is currently used. If change is detected,
it will signal to the main sync loop to restart with the updated
config. This includes restarting the informer and the job controller
if the configuration specifies use Job to clean block devices.
This change will enhance the deployment and rollout story
for the provisioner as updates to the ConfigMap will be picked up
automatically by the provisioner without needing to explicitly
restart the pod itself.

Signed-off By: Yibo Zhuang <yibzhuang@gmail.com>

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #302 

**Special notes for your reviewer**:


**Release note**:
```
Support for watching ConfigMap changes and restarting main sync loop including informer and job controller (if specified)
```
