### PR TITLE
Multi linux arch and multi windows distro builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lookup = $(word $(call pos,$1,$2),$3)
 all: build-container-linux-amd64
 .PHONY: all
 
-cross: check-env init-buildx \
+cross: init-buildx \
 	$(addprefix build-and-push-container-linux-,$(LINUX_ARCH)) \
 	$(addprefix build-and-push-container-windows-,$(WINDOWS_DISTROS))
 .PHONY: cross
@@ -103,14 +103,3 @@ init-buildx:
 	gcloud auth configure-docker --quiet
 .PHONY: init-buildx
 
-check-env-os:
-ifndef OS
-	$(error OS is not set)
-endif
-.PHONY: check-env-os
-
-check-env-arch:
-ifndef ARCH
-	$(error ARCH is not set)
-endif
-.PHONY: check-env-arch

--- a/Makefile
+++ b/Makefile
@@ -15,35 +15,37 @@
 REGISTRY ?= k8s.gcr.io/sig-storage
 VERSION ?= latest
 GOVERSION ?= 1.17
-ARCH ?= amd64
 
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+# These env vars have default values set from hack/release.sh, the values
+# shown here are for `make` and `make verify` only
+LINUX_ARCH ?= amd64
+WINDOWS_DISTROS ?=
 
-IMAGE = $(REGISTRY)/local-volume-provisioner-$(ARCH):$(VERSION)
-MUTABLE_IMAGE = $(REGISTRY)/local-volume-provisioner-$(ARCH):latest
+WINDOWS_BASE_IMAGES=$(addprefix mcr.microsoft.com/windows/servercore:,$(WINDOWS_DISTROS))
 
-TEMP_DIR := $(shell mktemp -d)
-QEMUVERSION = v2.9.1
+DOCKER=DOCKER_CLI_EXPERIMENTAL=enabled docker
+STAGINGVERSION=${VERSION}
+STAGINGIMAGE=${REGISTRY}/local-volume-provisioner
 
-ifeq ($(ARCH),arm)
-	QEMUARCH = arm
-endif
-ifeq ($(ARCH),arm64)
-	QEMUARCH = aarch64
-endif
-ifeq ($(ARCH),ppc64le)
-	QEMUARCH = ppc64le
-endif
-ifeq ($(ARCH),s390x)
-	QEMUARCH = s390x
-endif
-   
 SUDO = $(if $(filter 0,$(shell id -u)),,sudo)
 
-all: provisioner
+# $(call pos,slice,wanted)
+# finds the index of `wanted` in `slice`
+_pos = $(if $(findstring $1,$2),$(call _pos,$1,\
+       $(wordlist 2,$(words $2),$2),x $3),$3)
+pos = $(words $(call _pos,$1,$2))
+
+# $(call lookup,wanted,list1,list2)
+# finds the index of `wanted` in list1, then, it returns the element of `list2`
+# at that index
+lookup = $(word $(call pos,$1,$2),$3)
+
+all: build-container-linux-amd64
 .PHONY: all
 
-cross: $(addprefix provisioner-,$(ALL_ARCH))
+cross: check-env init-buildx \
+	$(addprefix build-and-push-container-linux-,$(LINUX_ARCH)) \
+	$(addprefix build-and-push-container-windows-,$(WINDOWS_DISTROS))
 .PHONY: cross
 
 verify:
@@ -58,29 +60,57 @@ release:
 	./hack/release.sh
 .PHONY: release
 
-provisioner-%: 
-	$(MAKE) ARCH=$* provisioner
+# used in `make test` and `make e2e`
+# builds without pushing to the registry
+build-container-linux-%:
+	$(DOCKER) buildx build --file=./deployment/docker/Dockerfile --platform=linux/$* \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_$* \
+		--build-arg OS=linux \
+		--build-arg ARCH=$* \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
 
-provisioner:
-	mkdir -p _output
-	# because COPY does not expand build arguments, we need substitute it
-	cat ./deployment/docker/Dockerfile \
-		| sed "s|QEMUARCH|$(QEMUARCH)|g" \
-		> $(TEMP_DIR)/Dockerfile
-ifneq ($(ARCH),amd64)
-	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
-	$(SUDO) ./third_party/multiarch/qemu-user-static/register/register.sh --reset
-endif
-	docker build -t $(MUTABLE_IMAGE) --build-arg GOVERSION=$(GOVERSION) --build-arg ARCH=$(ARCH) -f $(TEMP_DIR)/Dockerfile .
-	docker tag $(MUTABLE_IMAGE) $(IMAGE)
-	rm -rf $(TEMP_DIR)
-.PHONY: provisioner
+build-and-push-container-linux-%: init-buildx
+	$(DOCKER) buildx build --file=./deployment/docker/Dockerfile --platform=linux/$* \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_$* \
+		--build-arg OS=linux \
+		--build-arg ARCH=$* \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push .
 
-test: provisioner
+build-and-push-container-windows-%: init-buildx
+	$(DOCKER) buildx build --file=./deployment/docker/Dockerfile.Windows --platform=windows/amd64 \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_windows_$* \
+		--build-arg BASE_IMAGE=$(call lookup,$*,$(WINDOWS_DISTROS),$(WINDOWS_BASE_IMAGES)) \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push .
+
+test: build-container-linux-amd64
 	go test ./cmd/... ./pkg/...
-	docker run --privileged -v $(PWD)/deployment/docker/test.sh:/test.sh --entrypoint bash $(IMAGE) /test.sh
+	docker run --privileged -v $(PWD)/deployment/docker/test.sh:/test.sh --entrypoint bash $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 /test.sh
 .PHONY: test
 
 clean:
 	rm -rf _output
 .PHONY: clean
+
+init-buildx:
+	# Ensure we use a builder that can leverage it (the default on linux will not)
+	-$(DOCKER) buildx rm multiarch-multiplatform-builder
+	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder
+	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
+	# Register gcloud as a Docker credential helper.
+	# Required for "docker buildx build --push".
+	gcloud auth configure-docker --quiet
+.PHONY: init-buildx
+
+check-env-os:
+ifndef OS
+	$(error OS is not set)
+endif
+.PHONY: check-env-os
+
+check-env-arch:
+ifndef ARCH
+	$(error ARCH is not set)
+endif
+.PHONY: check-env-arch

--- a/deployment/docker/Dockerfile.Windows
+++ b/deployment/docker/Dockerfile.Windows
@@ -1,0 +1,38 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG BASE_IMAGE
+ARG GOVERSION=1.17
+ARG STAGINGVERSION
+
+FROM --platform=$BUILDPLATFORM golang:${GOVERSION}-alpine AS builder
+ARG OS=windows
+ARG ARCH=amd64
+ARG STAGINGVERSION
+WORKDIR /go/src/sigs.k8s.io/sig-storage-local-static-provisioner
+ADD . .
+RUN echo "OS: $OS ARCH: $ARCH"
+RUN GO111MODULE=off CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags='-extldflags="-static" -X="main.version=${STAGINGVERSION}"' -o _output/${OS}/${ARCH}/local-volume-provisioner.exe ./cmd/local-volume-provisioner
+
+FROM ${BASE_IMAGE}
+ARG OS=windows
+ARG ARCH=amd64
+LABEL description="Local Volume Provisioner"
+COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/${OS}/${ARCH}/local-volume-provisioner.exe /local-provisioner.exe
+
+# this image can't run in privileged mode so even porting these scripts to
+# powershell might not help, CSI Proxy can help with some privileged
+# storage operations
+# ADD deployment/docker/scripts /scripts
+
+ENTRYPOINT ["/local-provisioner.exe"]

--- a/deployment/docker/Dockerfile.Windows
+++ b/deployment/docker/Dockerfile.Windows
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,19 +16,15 @@ ARG GOVERSION=1.17
 ARG STAGINGVERSION
 
 FROM --platform=$BUILDPLATFORM golang:${GOVERSION}-alpine AS builder
-ARG OS=windows
-ARG ARCH=amd64
 ARG STAGINGVERSION
 WORKDIR /go/src/sigs.k8s.io/sig-storage-local-static-provisioner
 ADD . .
-RUN echo "OS: $OS ARCH: $ARCH"
-RUN GO111MODULE=off CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags='-extldflags="-static" -X="main.version=${STAGINGVERSION}"' -o _output/${OS}/${ARCH}/local-volume-provisioner.exe ./cmd/local-volume-provisioner
+RUN echo "OS: windows ARCH: amd64"
+RUN GO111MODULE=off CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -a -ldflags='-extldflags="-static" -X="main.version=${STAGINGVERSION}"' -o _output/windows/amd64/local-volume-provisioner.exe ./cmd/local-volume-provisioner
 
 FROM ${BASE_IMAGE}
-ARG OS=windows
-ARG ARCH=amd64
 LABEL description="Local Volume Provisioner"
-COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/${OS}/${ARCH}/local-volume-provisioner.exe /local-provisioner.exe
+COPY --from=builder /go/src/sigs.k8s.io/sig-storage-local-static-provisioner/_output/windows/amd64/local-volume-provisioner.exe /local-provisioner.exe
 
 # this image can't run in privileged mode so even porting these scripts to
 # powershell might not help, CSI Proxy can help with some privileged

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -50,6 +50,8 @@ Environments:
     ALLOW_OVERRIDE              by default, stable image is not allowed to override, set this to skip (debug only)
     SKIP_BUILD                  set this to skip build phase (debug only)
     SKIP_PUSH_LATEST            set this to skip pushing the latest stable image as the latest image
+    LINUX_ARCH                  Linux architectures to build
+    WINDOWS_DISTROS             Windows distros to build
 
 Examples:
 
@@ -64,7 +66,7 @@ Examples:
 
 3) Release multi-arch image to your own registry
 
-    REGISTRY=quay.io/<yourname> LINUX_ARCH="amd64 arm64" ./hack/release.sh
+    REGISTRY=quay.io/<yourname> LINUX_ARCH="amd64 arm64" WINDOWS_DISTROS="ltsc2019 1909" ./hack/release.sh
 
 EOF
 }

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -80,8 +80,8 @@ fi
 
 # build image if not specified
 if [ -z "$PROVISIONER_E2E_IMAGE" ]; then
-    make provisioner
-    PROVISIONER_E2E_IMAGE=" k8s.gcr.io/sig-storage/local-volume-provisioner-amd64:latest"
+    make
+    PROVISIONER_E2E_IMAGE=" k8s.gcr.io/sig-storage/local-volume-provisioner:latest_linux_amd64"
 else
     docker pull $PROVISIONER_E2E_IMAGE
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind feature

**What this PR does / why we need it**:

Adds support for multi windows distro builds, a summary of the changes:

- Moved from `docker build` to `docker buildx`
- Support for all the Windows distros (minus 2022)

I tested this with:

```
REGISTRY=gcr.io/mauriciopoppe-gke-dev ALLOW_UNSTABLE=true ALLOW_DIRTY=true VERSION=canary ./hack/release.sh
```

And commented parts of the code to push `latest` too, the output is:

![image](https://user-images.githubusercontent.com/1616682/137981100-b7fda343-f1ac-4eca-8bd5-2a188e8395a4.png)

Manifest contents:

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1160,
         "digest": "sha256:02b65ab8f73d9317e5ff84ee378551bee68a4e85948a795cad7689802a01401e",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1160,
         "digest": "sha256:aa0df19f3ca9b720e14d14e9b37fc9aaccbc7984dabb7567e3d757aa86f9dafd",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1160,
         "digest": "sha256:3112838cb4f22608044ccbb1565472209f6a3c81a91ceb0db2aa804d19af21f5",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1160,
         "digest": "sha256:ba735b867e126750d15c0c4258ce5492f4945aa6c724e9e36e08bc50dfc624ed",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1160,
         "digest": "sha256:9b195a6672192458f2290e90bcbca305c44fdad671b714ff7d2c62dbeb81395d",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:9b00b04c86a31af4e4ff17ba319675e845adf0b22ff4d299dae18105c55e8b31",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.18363.1556"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 957,
         "digest": "sha256:f1239689b5a9b55420ce1487bf38feb4cb538335654e884d43f17fac4c13e984",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19041.1288"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 957,
         "digest": "sha256:682fbdb80ef2248502c81aa7ddd0f61e896473db87204b1ccd22970e08433b16",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.1288"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:7065d5e721771113f6fd6d69a6384cc6935749688ff11f2fcfe8a41178fc5fc4",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.2237"
         }
      }
   ]
}
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #266

**Release note**:
```
Support for multi Windows distro builds
```

/sig storage
/cc @jingxu97 @cofyc 