### PR TITLE
Added FsCleanerCommand and updated cleaning scripts

### DIFF
--- a/deployment/docker/scripts/clean_symlink.sh
+++ b/deployment/docker/scripts/clean_symlink.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+# $ clean_symlink.sh
+
+# Import common functions.
+. $(dirname "$0")/common.sh
+
+if [ "$1" == "-h" ]; then
+  echo "Usage: $(basename $0) "
+  echo "Does a quick overwrite of current file system and calls wipefs to remove any signatures."
+  echo "The block device must be specified by the environment variable LOCAL_PV_BLKDEVICE"
+  exit 0
+fi
+
+
+# Validate that we got a valid block device to cleanup
+validateBlockDevice
+
+echo "Calling mkfs"
+ionice -c 3 mkfs -F $LOCAL_PV_BLKDEVICE
+
+echo "Calling wipefs"
+ionice -c 3 wipefs -a $LOCAL_PV_BLKDEVICE
+
+echo "Quick reset completed"
+
+
+echo "Cleaning the symlink for the device $LOCAL_PV_BLKDEVICE "
+rm $LOCAL_PV_BLKDEVICE

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -120,6 +120,7 @@ func TestLoadProvisionerConfigs(t *testing.T) {
 						HostDir:             "/mnt/disks",
 						MountDir:            "/mnt/disks",
 						BlockCleanerCommand: []string{"/scripts/shred.sh", "2"},
+						FsCleanerCommand:    []string{"/scripts/fsclean.sh"},
 						VolumeMode:          "Filesystem",
 						FsType:              "ext4",
 						NamePattern:         "nvm*",

--- a/pkg/deleter/deleter_test.go
+++ b/pkg/deleter/deleter_test.go
@@ -102,7 +102,7 @@ func TestDeleteVolumes_Basic(t *testing.T) {
 		vols:               vols,
 		expectedDeletedPVs: expectedDeletedPVs,
 	}
-	d := testSetupForProcCleaning(t, test, nil)
+	d := testSetupForProcCleaning(t, test, []string{common.DefaultFsCleanerCommand})
 
 	d.DeletePVs()
 	waitForAsyncToComplete(t, d, "pv4")
@@ -120,7 +120,7 @@ func TestDeleteVolumes_Twice(t *testing.T) {
 		vols:               vols,
 		expectedDeletedPVs: expectedDeletedPVs,
 	}
-	d := testSetupForProcCleaning(t, test, nil)
+	d := testSetupForProcCleaning(t, test, []string{common.DefaultFsCleanerCommand})
 
 	d.DeletePVs()
 	waitForAsyncToComplete(t, d)
@@ -176,7 +176,7 @@ func TestDeleteVolumes_DeletePVNotFound(t *testing.T) {
 		vols:               vols,
 		expectedDeletedPVs: map[string]string{"pv4": ""},
 	}
-	d := testSetupForProcCleaning(t, test, nil)
+	d := testSetupForProcCleaning(t, test, []string{common.DefaultFsCleanerCommand})
 
 	d.DeletePVs()
 	waitForAsyncToComplete(t, d)
@@ -209,7 +209,7 @@ func TestDeleteVolumes_UnsupportedReclaimPolicy(t *testing.T) {
 		vols:               vols,
 		expectedDeletedPVs: map[string]string{},
 	}
-	d := testSetupForProcCleaning(t, test, nil)
+	d := testSetupForProcCleaning(t, test, []string{common.DefaultFsCleanerCommand})
 
 	d.DeletePVs()
 	waitForAsyncToComplete(t, d)
@@ -244,7 +244,7 @@ func TestDeleteVolumes_UnknownReclaimPolicy(t *testing.T) {
 		vols:               vols,
 		expectedDeletedPVs: map[string]string{},
 	}
-	d := testSetupForProcCleaning(t, test, nil)
+	d := testSetupForProcCleaning(t, test, []string{common.DefaultFsCleanerCommand})
 
 	d.DeletePVs()
 	waitForAsyncToComplete(t, d)
@@ -278,7 +278,7 @@ func TestDeleteVolumes_CleanupFails(t *testing.T) {
 		vols:                vols,
 		expectedDeletedPVs:  map[string]string{},
 	}
-	d := testSetupForProcCleaning(t, test, nil)
+	d := testSetupForProcCleaning(t, test, []string{common.DefaultFsCleanerCommand})
 
 	d.DeletePVs()
 	waitForAsyncToComplete(t, d)
@@ -603,6 +603,7 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 				HostDir:             testHostDir,
 				MountDir:            testMountDir,
 				BlockCleanerCommand: cleanupCmd,
+				FsCleanerCommand:    cleanupCmd,
 			},
 		},
 		Node: &v1.Node{ObjectMeta: meta_v1.ObjectMeta{

--- a/pkg/deleter/jobcontroller.go
+++ b/pkg/deleter/jobcontroller.go
@@ -267,9 +267,7 @@ func NewCleanupJob(pv *apiv1.PersistentVolume, volMode apiv1.PersistentVolumeMod
 		jobContainer.Command = config.BlockCleanerCommand
 		jobContainer.Env = []apiv1.EnvVar{{Name: common.LocalPVEnv, Value: mountPath}}
 	} else if volMode == apiv1.PersistentVolumeFilesystem {
-		// We only have one way to clean filesystem, so no need to customize
-		// filesystem cleaner command.
-		jobContainer.Command = []string{"/scripts/fsclean.sh"}
+		jobContainer.Command = config.FsCleanerCommand
 		jobContainer.Env = []apiv1.EnvVar{{Name: common.LocalFilesystemEnv, Value: mountPath}}
 	} else {
 		return nil, fmt.Errorf("unknown PersistentVolume mode: %v", volMode)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
The BlockCleanerCommand doesn't act on filesystem PVs so added
FsCleanerCommand and added a script for quick cleanup and remove symlink.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes # `, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #262

**Special notes for your reviewer**:


**Release note**:
```

```
