### PR TITLE
Prevent cleaning released volumes more than once

### DIFF
--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -72,6 +72,9 @@ func (d *Deleter) DeletePVs() {
 		if pv.Status.Phase != v1.VolumeReleased {
 			continue
 		}
+		if d.Cache.SuccessfullyCleanedPV(pv) {
+			continue
+		}
 		name := pv.Name
 		switch pv.Spec.PersistentVolumeReclaimPolicy {
 		case v1.PersistentVolumeReclaimRetain:
@@ -162,6 +165,7 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 	switch state {
 	case CSSucceeded:
 		// Found a completed cleaning entry
+		d.Cache.CleanPV(pv)
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
 			if !errors.IsNotFound(err) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There is a small time window between the deleter finding a successfully
completed cleanup job and the cache entry being removed in which
DeletePVs() may be called again. If this happens, then a second cleanup
job may be started before the cache entry is removed. This fix prevents
starting another cleanup job for a cache entry that has already been
cleaned successfully.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
This issue was originally encountered in a downstream component:
https://bugzilla.redhat.com/show_bug.cgi?id=2032924
/cc @gnufied @jsafrane

**Release note**:
```
NONE
```
