### PR TITLE
Bump Dockerfile debian image to v1.10.0

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN GO111MODULE=off CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -ldflags
 
 # For security, we use kubernetes community maintained debian base image.
 # https://github.com/kubernetes/release/tree/master/images/build/debian-base
-FROM k8s.gcr.io/build-image/debian-base-${ARCH}:buster-v1.8.0
+FROM k8s.gcr.io/build-image/debian-base-${ARCH}:buster-v1.10.0
 ARG OS=linux
 ARG ARCH=amd64
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:
Bumps the base image to v1.10.0.

**Release note**:
```release-note
Bump base docker image to k8s.gcr.io/build-image/debian-base-amd64:buster-v1.10.0
```

/cc @msau42 