### PR TITLE
Increase build timeout to 2h

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,8 @@
 #
 #    gcloud builds submit --verbosity info --substitutions _STAGING_PROJECT=<your-project>,_PULL_BASE_REF=master [SOURCE]
 #
-timeout: 1800s
+# 5400s = 1h30m
+timeout: 5400s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:
Increases the build timeout to 1h30m, with that the sig-storage-image-build canary job should pass (right now it's timing out at 30m https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/canary-sig-storage-local-static-provisioner-push-images/1516187005245984768).

Should fix canary builds for sig-storage-image-build

**Release note**:
```release-note
NONE
```

/assign @msau42 