### PR TITLE
fix: init-buildx build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ clean:
 
 init-buildx:
 	# Ensure we use a builder that can leverage it (the default on linux will not)
-	-$(DOCKER) buildx rm multiarch-multiplatform-builder
+	$(DOCKER) buildx rm multiarch-multiplatform-builder || true
 	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder
 	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
 	# Register gcloud as a Docker credential helper.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:
fix: init-buildx build failure

Now the pipeline failed with:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/canary-sig-storage-local-static-provisioner-push-images/1516187005245984768
```
# Ensure we use a builder that can leverage it (the default on linux will not)
DOCKER_CLI_EXPERIMENTAL=enabled docker buildx rm multiarch-multiplatform-builder
error: no builder "multiarch-multiplatform-builder" found
make: [Makefile:96: init-buildx] Error 1 (ignored)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
none
```
