### PR TITLE
feat: support namePattern as a list

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -84,7 +84,7 @@ const (
 	// DefaultVolumeMode is the default volume mode of created PV object.
 	DefaultVolumeMode = "Filesystem"
 
-	// DefaultNamePattern is the default name pattern of in PV discovery.
+	// DefaultNamePattern is the default name pattern list (separated by comma) of in PV discovery.
 	DefaultNamePattern = "*"
 )
 

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -109,7 +109,7 @@ func TestLoadProvisionerConfigs(t *testing.T) {
      - "2"
    volumeMode: Filesystem
    fsType: ext4
-   namePattern: nvm*
+   namePattern: nvm*,sdb*
 `,
 				"useAlphaAPI":     "true",
 				"minResyncPeriod": "1h30m",
@@ -122,7 +122,7 @@ func TestLoadProvisionerConfigs(t *testing.T) {
 						BlockCleanerCommand: []string{"/scripts/shred.sh", "2"},
 						VolumeMode:          "Filesystem",
 						FsType:              "ext4",
-						NamePattern:         "nvm*",
+						NamePattern:         "nvm*,sdb*",
 					},
 				},
 				UseAlphaAPI: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support namePattern as a list
https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/187 add `namePattern` parameter, this PR supports namePattern as a list separated by a comma, following `namePattern` are both valid:
 - `nvm*`
 - `nvm*,sdb*`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
feat: support namePattern as a list
```
