### PR TITLE
fix: set admin user in windows image build

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           check_filenames: true
           skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh,./helm/provisioner/values.yaml
-          ignore_words_list: "AKS,aks,LKE,lke"
+          ignore_words_list: "AKS,aks,LKE,lke,ro"

--- a/deployment/docker/Dockerfile.Windows
+++ b/deployment/docker/Dockerfile.Windows
@@ -25,4 +25,5 @@ COPY ${binary} /local-provisioner.exe
 # storage operations
 # ADD deployment/docker/scripts /scripts
 
+USER ContainerAdministrator
 ENTRYPOINT ["/local-provisioner.exe"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: set admin user in windows image build
This PR fixes the following problem: `failed to connect to csi-proxy v1beta with error=open \\.\\pipe\\csi-proxy-volume-v1beta2: Access is denied`

<details>

```
I1007 12:40:03.767056    3796 common.go:348] StorageClass "local-disk" configured with MountDir "c:\\dev", HostDir "c:\\dev", VolumeMode "Filesystem", FsType "ext4", BlockCleanerCommand ["/scripts/shred.sh" "2"], NamePattern "nvme*"
I1007 12:40:04.066660    3796 main.go:66] Loaded configuration: {StorageClassConfig:map[local-disk:{HostDir:c:\dev MountDir:c:\dev BlockCleanerCommand:[/scripts/shred.sh 2] VolumeMode:Filesystem FsType:ext4 NamePattern:nvme*}] NodeLabelsForPV:[] UseAlphaAPI:false UseJobForCleaning:false MinResyncPeriod:{Duration:5m0s} UseNodeNameOnly:false LabelsForPV:map[] SetPVOwnerRef:false}
I1007 12:40:04.066660    3796 main.go:67] Ready to run...
I1007 12:40:04.069659    3796 common.go:425] Creating client using in-cluster config
I1007 12:40:04.091705    3796 main.go:132] Could not get node information (remaining retries: 2): Get "https://andy-aks1219-dns-a2701255.hcp.uksouth.azmk8s.io:443/api/v1/nodes/akswin000000": dial tcp: lookup andy-aks1219-dns-a2701255.hcp.uksouth.azmk8s.io: no such host
I1007 12:40:05.296040    3796 main.go:88] Starting controller
I1007 12:40:05.296040    3796 main.go:105] Starting metrics server at :8080
I1007 12:40:05.296040    3796 controller.go:47] Initializing volume cache
E1007 12:40:05.296040    3796 csi_proxy_windows.go:59] failed to connect to csi-proxy v1beta with error=open \\.\\pipe\\csi-proxy-volume-v1beta2: Access is denied.
F1007 12:40:05.296040    3796 controller.go:68] Error initializing VolumeUtil: open \\.\\pipe\\csi-proxy-volume-v1beta2: Access is denied.
goroutine 12 [running]:
k8s.io/klog/v2.stacks(0x1)
        /workspace/vendor/k8s.io/klog/v2/klog.go:1140 +0x8a
k8s.io/klog/v2.(*loggingT).output(0x31f1a00, 0x3, 0x0, 0xc000457260, 0x0, {0x28be7de, 0x1}, 0xc0000b9a10, 0x0)
        /workspace/vendor/k8s.io/klog/v2/klog.go:1088 +0x66f
k8s.io/klog/v2.(*loggingT).printf(0x2, 0x0, 0x0, {0x0, 0x0}, {0x22883f2, 0x21}, {0xc0000b9a10, 0x1, 0x1})
        /workspace/vendor/k8s.io/klog/v2/klog.go:753 +0x1c5
k8s.io/klog/v2.Fatalf(...)
        /workspace/vendor/k8s.io/klog/v2/klog.go:1642
sigs.k8s.io/sig-storage-local-static-provisioner/pkg/controller.StartLocalController(0xc000334480, {0x24d3420, 0xc0003ed320}, 0x24df038, 0xc0004572d0)
        /workspace/pkg/controller/controller.go:68 +0x4ce
created by main.main
        /workspace/cmd/local-volume-provisioner/main.go:91 +0x8e5

goroutine 1 [IO wait]:
internal/poll.runtime_pollWait(0x1dabc4e4fb0, 0x72)
        /usr/local/go/src/runtime/netpoll.go:234 +0x89
internal/poll.(*pollDesc).wait(0xc00001da28, 0xd1d574, 0x0)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x32
```

</details>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
fix: set admin user in windows image build
```
