### PR TITLE
Use latest image in daemonset, add node selector for Windows

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -110,12 +110,21 @@ helm upgrade ./helm/provisioner -f <path-to-your-values-file> <release-name>
 
 ### helm version  >= v3.0.0
 
-Install via helm template:
+Install by adding the repo as a Helm repo:
+
+```sh
+helm repo add sig-storage-local-static-provisioner https://kubernetes-sigs.github.io/sig-storage-local-static-provisioner
+helm template --debug sig-storage-local-static-provisioner/local-static-provisioner --version <version> --namespace <namespace> > local-volume-provisioner.generated.yaml
+# edit local-volume-provisioner.generated.yaml if necessary
+kubectl create -f local-volume-provisioner.generated.yaml
+```
+
+Or install by cloning the repo locally:
 
 ```console
 git clone --depth=1 https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner.git
 helm template -f <path-to-your-values-file> <release-name> --namespace <namespace> ./helm/provisioner > local-volume-provisioner.generated.yaml
-edit local-volume-provisioner.generated.yaml if necessary
+# edit local-volume-provisioner.generated.yaml if necessary
 kubectl create -f local-volume-provisioner.generated.yaml
 ```
 

--- a/helm/generated_examples/baremetal-affinity.yaml
+++ b/helm/generated_examples/baremetal-affinity.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,29 +92,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -131,7 +131,7 @@ spec:
                 - localssd
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -144,7 +144,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -168,29 +168,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -211,7 +211,7 @@ spec:
                 - localssd
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -222,7 +222,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-cleanbyjobs.yaml
+++ b/helm/generated_examples/baremetal-cleanbyjobs.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "/scripts/quick_reset.sh"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,15 +92,15 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: local-static-provisioner-jobs-role
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -111,15 +111,15 @@ rules:
   verbs:
     - '*'
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: local-static-provisioner-jobs-rolebinding
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -131,36 +131,36 @@ roleRef:
   name: local-static-provisioner-jobs-role
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: f76f7144cfed1234a43ab846cb19c4978dfea1c17f83be2a6bf0ef1dfac391f2
+        checksum/config: 9459f3c42d71e4ea6b92cddee0dd3ce4d1561a193fe1507aca334ee140ce039f
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -173,7 +173,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -197,29 +197,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: f76f7144cfed1234a43ab846cb19c4978dfea1c17f83be2a6bf0ef1dfac391f2
+        checksum/config: 9459f3c42d71e4ea6b92cddee0dd3ce4d1561a193fe1507aca334ee140ce039f
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -230,7 +230,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -241,7 +241,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-default-storage.yaml
+++ b/helm/generated_examples/baremetal-default-storage.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -29,7 +29,7 @@ data:
       mountDir: /mnt/disks
       volumeMode: Filesystem
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -37,22 +37,22 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -72,14 +72,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -91,36 +91,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: e3ec0554361fa1a37e6620f6b26f7ac3d7343ba262f00a84b6a60f0cf9e22940
+        checksum/config: cb0fc70b6e2eaef88fca39b5e683f694ab36804c670e82409834a2b7c9723663
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -133,7 +133,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -157,29 +157,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: e3ec0554361fa1a37e6620f6b26f7ac3d7343ba262f00a84b6a60f0cf9e22940
+        checksum/config: cb0fc70b6e2eaef88fca39b5e683f694ab36804c670e82409834a2b7c9723663
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -190,7 +190,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -201,7 +201,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-nodeselector.yaml
+++ b/helm/generated_examples/baremetal-nodeselector.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,29 +92,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -123,7 +123,7 @@ spec:
         localVolume: present
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -136,7 +136,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -160,29 +160,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -193,7 +193,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -204,7 +204,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-priority-critical.yaml
+++ b/helm/generated_examples/baremetal-priority-critical.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,29 +92,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       priorityClassName: system-node-critical
@@ -122,7 +122,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -135,7 +135,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -159,29 +159,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       priorityClassName: system-node-critical
@@ -193,7 +193,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -204,7 +204,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-priority-noncritical.yaml
+++ b/helm/generated_examples/baremetal-priority-noncritical.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,29 +92,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       priorityClassName: priority-important
@@ -122,7 +122,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -135,7 +135,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -159,29 +159,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       priorityClassName: priority-important
@@ -193,7 +193,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -204,7 +204,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-prometheus.yaml
+++ b/helm/generated_examples/baremetal-prometheus.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,15 +92,15 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/servicemonitor.yaml
+# Source: local-static-provisioner/templates/servicemonitor.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
@@ -110,39 +110,39 @@ spec:
       targetPort: 8080
       name: metrics
   selector:
-    app.kubernetes.io/name: provisioner
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -155,7 +155,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -179,29 +179,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -212,7 +212,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -223,7 +223,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -279,15 +279,15 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/servicemonitor.yaml
+# Source: local-static-provisioner/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
@@ -301,5 +301,5 @@ spec:
       - default
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner

--- a/helm/generated_examples/baremetal-resyncperiod.yaml
+++ b/helm/generated_examples/baremetal-resyncperiod.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "/scripts/quick_reset.sh"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,36 +92,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: c4f0924708dc00e9b9ea63c4082d8619119f8e607d61bda77b501bdffab3ac0b
+        checksum/config: d4edde2b4c135002df4b780eaf2e54312aeb9840c2413114907637bc54ef16ba
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -134,7 +134,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -158,29 +158,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: c4f0924708dc00e9b9ea63c4082d8619119f8e607d61bda77b501bdffab3ac0b
+        checksum/config: d4edde2b4c135002df4b780eaf2e54312aeb9840c2413114907637bc54ef16ba
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -191,7 +191,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -202,7 +202,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,29 +92,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -125,7 +125,7 @@ spec:
           key: node-role.kubernetes.io/master
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -138,7 +138,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -162,29 +162,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -198,7 +198,7 @@ spec:
           key: node-role.kubernetes.io/master
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -209,7 +209,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-with-resource-limits.yaml
+++ b/helm/generated_examples/baremetal-with-resource-limits.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,36 +92,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           resources:
@@ -142,7 +142,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -166,29 +166,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -199,7 +199,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           resources:
             
             limits:
@@ -218,7 +218,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-without-rbac.yaml
+++ b/helm/generated_examples/baremetal-without-rbac.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -31,50 +31,50 @@ data:
         - "/scripts/quick_reset.sh"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: b9c0c22e49130f7f4a0315d6c2cfb550eac84e19315ecaf2ec11cccbde5ca72f
+        checksum/config: 400bb07c43d1299b23a79ec7c30fab149be9562c4a081573c2d6f2ecada2397c
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -87,7 +87,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -111,29 +111,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: b9c0c22e49130f7f4a0315d6c2cfb550eac84e19315ecaf2ec11cccbde5ca72f
+        checksum/config: 400bb07c43d1299b23a79ec7c30fab149be9562c4a081573c2d6f2ecada2397c
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -144,7 +144,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -155,7 +155,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal.yaml
+++ b/helm/generated_examples/baremetal.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,28 +32,28 @@ data:
         - "2"
       volumeMode: Block
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -73,14 +73,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -92,36 +92,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -134,7 +134,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -158,29 +158,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 49fd0db6c0e3bc6c0607d6f94132b4bd3a4b7445efd977e564038e93320045cf
+        checksum/config: 26ec1983f036e7702e8b97e6294f51995f9e78c8bb812e7ca5468a45a2df2a04
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -191,7 +191,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -202,7 +202,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/development-gce.yaml
+++ b/helm/generated_examples/development-gce.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -29,28 +29,28 @@ data:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-scsi
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -70,14 +70,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -89,29 +89,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: ba427f125669bcd3de18515b53bfedb00a0ab139487754b882fda4fa65a4c7be
+        checksum/config: eba6b2165051773e704189243effea3957d506fed980dd8aef218a5c5cebb095
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -156,29 +156,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: ba427f125669bcd3de18515b53bfedb00a0ab139487754b882fda4fa65a4c7be
+        checksum/config: eba6b2165051773e704189243effea3957d506fed980dd8aef218a5c5cebb095
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:

--- a/helm/generated_examples/development-gke.yaml
+++ b/helm/generated_examples/development-gke.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -29,28 +29,28 @@ data:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-scsi
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -70,14 +70,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -89,29 +89,29 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: ba427f125669bcd3de18515b53bfedb00a0ab139487754b882fda4fa65a4c7be
+        checksum/config: eba6b2165051773e704189243effea3957d506fed980dd8aef218a5c5cebb095
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -156,29 +156,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: ba427f125669bcd3de18515b53bfedb00a0ab139487754b882fda4fa65a4c7be
+        checksum/config: eba6b2165051773e704189243effea3957d506fed980dd8aef218a5c5cebb095
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:

--- a/helm/generated_examples/eks-nvme-ssd.yaml
+++ b/helm/generated_examples/eks-nvme-ssd.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -28,28 +28,28 @@ data:
       hostDir: /dev/disk/kubernetes
       mountDir: /dev/disk/kubernetes
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: nvme-ssd
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -69,14 +69,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -88,36 +88,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 9020bc1a8cc0d5f9d8448c43038ddd5c545eb18c2bb01d6fb8136ffe2fd78e09
+        checksum/config: 0d9a1966f57c24a094b5590be3c14bd3bfeb962f21ba0fe921542a4ae4dba5b0
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -130,7 +130,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -154,29 +154,29 @@ spec:
           hostPath:
             path: /dev/disk/kubernetes
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 9020bc1a8cc0d5f9d8448c43038ddd5c545eb18c2bb01d6fb8136ffe2fd78e09
+        checksum/config: 0d9a1966f57c24a094b5590be3c14bd3bfeb962f21ba0fe921542a4ae4dba5b0
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -187,7 +187,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -198,7 +198,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce-pre1.9.yaml
+++ b/helm/generated_examples/gce-pre1.9.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -30,28 +30,28 @@ data:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-scsi
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -71,14 +71,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -90,36 +90,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 543b5a0f4f04334f76708ff41fb371253cd81f53f7139344235b50e1210cbb65
+        checksum/config: c5bf0373f6e249e8caaa74d5e37338564017053984bc00bbe6bf7268dd563b8f
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -132,7 +132,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -156,29 +156,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 543b5a0f4f04334f76708ff41fb371253cd81f53f7139344235b50e1210cbb65
+        checksum/config: c5bf0373f6e249e8caaa74d5e37338564017053984bc00bbe6bf7268dd563b8f
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -189,7 +189,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -200,7 +200,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce-retain.yaml
+++ b/helm/generated_examples/gce-retain.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,42 +32,42 @@ data:
       hostDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
       mountDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-scsi
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-nvme
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -87,14 +87,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -106,36 +106,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 8c8e36b2c7252150179aa46055665bab959e63bfcd6c76fb1f6f549ad3a2098e
+        checksum/config: 77ba09f0f2ba0e81f353a49ad509ae322f6a38b0c9371a0bff235da255a1fea7
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -148,7 +148,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -178,29 +178,29 @@ spec:
           hostPath:
             path: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 8c8e36b2c7252150179aa46055665bab959e63bfcd6c76fb1f6f549ad3a2098e
+        checksum/config: 77ba09f0f2ba0e81f353a49ad509ae322f6a38b0c9371a0bff235da255a1fea7
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -211,7 +211,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -222,7 +222,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce.yaml
+++ b/helm/generated_examples/gce.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -32,42 +32,42 @@ data:
       hostDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
       mountDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-scsi
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-nvme
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -87,14 +87,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -106,36 +106,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 8c8e36b2c7252150179aa46055665bab959e63bfcd6c76fb1f6f549ad3a2098e
+        checksum/config: 77ba09f0f2ba0e81f353a49ad509ae322f6a38b0c9371a0bff235da255a1fea7
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -148,7 +148,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -178,29 +178,29 @@ spec:
           hostPath:
             path: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 8c8e36b2c7252150179aa46055665bab959e63bfcd6c76fb1f6f549ad3a2098e
+        checksum/config: 77ba09f0f2ba0e81f353a49ad509ae322f6a38b0c9371a0bff235da255a1fea7
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -211,7 +211,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -222,7 +222,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
+++ b/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
@@ -1,32 +1,25 @@
-# 1. Run gcloud CLI with --local-nvme-ssd-block option to create a node pool with
-# raw block Local SSDs attached.
-# 2. Use gke-daemonset-raid-disks-raid.yaml to create DaemonSet. It will set RAID0 array
-# on all raw block Local SSD disks and format the device to an ext4 filesystem on each node.
-# 3. Use the gke-nvme-ssd-block.yaml to create PV and StorageClass
-# 4. Use gke-pvc-nvme-ssd-block.yaml and gke-pod-nvme-ssd-block.yaml to create
-# PVC and Pod
 ---
-# Source: local-volume-static-provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: local-static-provisioner-local-volume-static-provisioner
+  name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: local-volume-static-provisioner-1.0.0
-    app.kubernetes.io/name: local-volume-static-provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: local-volume-static-provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: local-static-provisioner-local-volume-static-provisioner-config
+  name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: local-volume-static-provisioner-1.0.0
-    app.kubernetes.io/name: local-volume-static-provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -36,28 +29,28 @@ data:
       hostDir: /mnt/disks/raid
       mountDir: /mnt/disks/raid
 ---
-# Source: local-volume-static-provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: nvme-ssd-block
   labels:
-    helm.sh/chart: local-volume-static-provisioner-1.0.0
-    app.kubernetes.io/name: local-volume-static-provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: local-volume-static-provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: local-static-provisioner-local-volume-static-provisioner-node-clusterrole
+  name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: local-volume-static-provisioner-1.0.0
-    app.kubernetes.io/name: local-volume-static-provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -77,55 +70,55 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: local-volume-static-provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: local-static-provisioner-local-volume-static-provisioner-node-binding
+  name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: local-volume-static-provisioner-1.0.0
-    app.kubernetes.io/name: local-volume-static-provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
 - kind: ServiceAccount
-  name: local-static-provisioner-local-volume-static-provisioner
+  name: local-static-provisioner
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: local-static-provisioner-local-volume-static-provisioner-node-clusterrole
+  name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: local-volume-static-provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: local-static-provisioner-local-volume-static-provisioner
+  name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: local-volume-static-provisioner-1.0.0
-    app.kubernetes.io/name: local-volume-static-provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: local-volume-static-provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: local-volume-static-provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: 450fc8f06342a5f9238c60cf3f1f9563f6e1fc24dffc754a0eebf0313b3f2f1c
+        checksum/config: 88521c153598cf5f2be2f5b5938b7d9aabc6e8f6fb0e13808681cc87300aeefa
     spec:
-      serviceAccountName: local-static-provisioner-local-volume-static-provisioner
+      serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -138,7 +131,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -154,10 +147,110 @@ spec:
       volumes:
         - name: provisioner-config
           configMap:
-            name: local-static-provisioner-local-volume-static-provisioner-config
+            name: local-static-provisioner-config
         - name: provisioner-dev
           hostPath:
             path: /dev
+        - name: nvme-ssd-block
+          hostPath:
+            path: /mnt/disks/raid
+---
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-static-provisioner-win
+  namespace: default
+  labels:
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: local-static-provisioner
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: local-static-provisioner
+      app.kubernetes.io/instance: local-static-provisioner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: local-static-provisioner
+        app.kubernetes.io/instance: local-static-provisioner
+      annotations:
+        checksum/config: 88521c153598cf5f2be2f5b5938b7d9aabc6e8f6fb0e13808681cc87300aeefa
+    spec:
+      serviceAccountName: local-static-provisioner
+      nodeSelector:
+        kubernetes.io/os: windows
+      tolerations:
+        # an empty key operator Exists matches all keys, values and effects
+        # which meants that this will tolerate everything
+        - operator: "Exists"
+      containers:
+        - name: provisioner
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          ports:
+          - name: metrics
+            containerPort: 8080
+          volumeMounts:
+            - name: provisioner-config
+              mountPath: /etc/provisioner/config
+              readOnly: true
+            - name: provisioner-dev
+              mountPath: /dev
+            - name: nvme-ssd-block
+              mountPath: /mnt/disks/raid
+              mountPropagation: HostToContainer
+            - name: csi-proxy-volume-v1
+              mountPath: \\.\pipe\csi-proxy-volume-v1
+            - name: csi-proxy-filesystem-v1
+              mountPath: \\.\pipe\csi-proxy-filesystem-v1
+            # these csi-proxy paths are still included for compatibility, they're used
+            # only if the node has still the beta version of the CSI proxy
+            - name: csi-proxy-volume-v1beta2
+              mountPath: \\.\pipe\csi-proxy-volume-v1beta2
+            - name: csi-proxy-filesystem-v1beta2
+              mountPath: \\.\pipe\csi-proxy-filesystem-v1beta2
+      volumes:
+        - name: csi-proxy-volume-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-volume-v1
+            type: ""
+        - name: csi-proxy-filesystem-v1
+          hostPath:
+            path: \\.\pipe\csi-proxy-filesystem-v1
+            type: ""
+        # these csi-proxy paths are still included for compatibility, they're used
+        # only if the node has still the beta version of the CSI proxy
+        - name: csi-proxy-volume-v1beta2
+          hostPath:
+            path: \\.\pipe\csi-proxy-volume-v1beta2
+            type: ""
+        - name: csi-proxy-filesystem-v1beta2
+          hostPath:
+            path: \\.\pipe\csi-proxy-filesystem-v1beta2
+            type: ""
+        - name: provisioner-config
+          configMap:
+            name: local-static-provisioner-config
+        - name: provisioner-dev
+          hostPath:
+            path: "C:\\dev"
+            # If nothing exists at the given path, an empty directory will be
+            # created there as needed with permission set to 0755,
+            # having the same group and ownership with Kubelet.
+            type: DirectoryOrCreate
         - name: nvme-ssd-block
           hostPath:
             path: /mnt/disks/raid

--- a/helm/generated_examples/gke.yaml
+++ b/helm/generated_examples/gke.yaml
@@ -1,25 +1,25 @@
 ---
-# Source: provisioner/templates/serviceaccount.yaml
+# Source: local-static-provisioner/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 ---
-# Source: provisioner/templates/configmap.yaml
+# Source: local-static-provisioner/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-static-provisioner-config
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
@@ -29,28 +29,28 @@ data:
       hostDir: /mnt/disks
       mountDir: /mnt/disks
 ---
-# Source: provisioner/templates/storageclass.yaml
+# Source: local-static-provisioner/templates/storageclass.yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-scsi
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: local-static-provisioner-node-clusterrole
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 rules:
@@ -70,14 +70,14 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 ---
-# Source: provisioner/templates/rbac.yaml
+# Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-static-provisioner-node-binding
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 subjects:
@@ -89,36 +89,36 @@ roleRef:
   name: local-static-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 ---
-# Source: provisioner/templates/daemonset_linux.yaml
+# Source: local-static-provisioner/templates/daemonset_linux.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: ba427f125669bcd3de18515b53bfedb00a0ab139487754b882fda4fa65a4c7be
+        checksum/config: eba6b2165051773e704189243effea3957d506fed980dd8aef218a5c5cebb095
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           securityContext:
             privileged: true
           env:
@@ -131,7 +131,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080
@@ -155,29 +155,29 @@ spec:
           hostPath:
             path: /mnt/disks
 ---
-# Source: provisioner/templates/daemonset_windows.yaml
+# Source: local-static-provisioner/templates/daemonset_windows.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: local-static-provisioner-win
   namespace: default
   labels:
-    helm.sh/chart: provisioner-2.6.0-alpha.1
-    app.kubernetes.io/name: provisioner
+    helm.sh/chart: local-static-provisioner-1.0.0
+    app.kubernetes.io/name: local-static-provisioner
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: provisioner
+      app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: provisioner
+        app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: ba427f125669bcd3de18515b53bfedb00a0ab139487754b882fda4fa65a4c7be
+        checksum/config: eba6b2165051773e704189243effea3957d506fed980dd8aef218a5c5cebb095
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:
@@ -188,7 +188,7 @@ spec:
         - operator: "Exists"
       containers:
         - name: provisioner
-          image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           env:
           - name: MY_NODE_NAME
             valueFrom:
@@ -199,7 +199,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/provisioner/Chart.yaml
+++ b/helm/provisioner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: local-volume-static-provisioner
+name: local-static-provisioner
 description: Helm chart for the SIG Storage Local Volume Static Provisioner.
 type: application
 version: 1.0.0

--- a/helm/provisioner/templates/daemonset_windows.yaml
+++ b/helm/provisioner/templates/daemonset_windows.yaml
@@ -34,6 +34,9 @@ spec:
 {{- end }}
       nodeSelector:
         kubernetes.io/os: windows
+{{- if .Values.daemonset.nodeSelectorWindows }}
+        {{ toYaml .Values.daemonset.nodeSelectorWindows | nindent 8 }}
+{{- end }}
       tolerations:
         # an empty key operator Exists matches all keys, values and effects
         # which meants that this will tolerate everything

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -113,7 +113,7 @@ daemonset:
   #
   # Defines Provisioner's image name including container registry.
   #
-  image: k8s.gcr.io/sig-storage/local-volume-provisioner:v2.4.0
+  image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
   #
   # Defines Image download policy, see kubernetes documentation for available values.
   #
@@ -131,6 +131,7 @@ daemonset:
   # NodeSelector constraint for local-volume-provisioner scheduling to nodes.
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   nodeSelector: {}
+  nodeSelectorWindows: {}
   #
   # If configured KubeConfigEnv will (optionally) specify the location of kubeconfig file on the node.
   #  kubeConfigEnv: KUBECONFIG


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
/kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Helm chart v1.0.0 uses registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0,  add field .Values.daemonset.nodeSelectorWindows to the helm chart.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #347

**Release note**:
```release-note
Helm chart v1.0.0 uses registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
Add field .Values.daemonset.nodeSelectorWindows to the helm chart.
```

/cc @andyzhangx 