### PR TITLE
Add controller to clean up stale PVs/PVCs when a Node is deleted

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"context"
-	"flag"
 	"time"
 
+	flag "github.com/spf13/pflag"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/controller"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/deleter"
@@ -16,13 +17,13 @@ import (
 
 // Command line flags
 var (
-	kubeconfig               = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Only required when running out of cluster.")
-	masterURL                = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	resync                   = flag.Duration("resync", 10*time.Minute, "Resync interval of the controller.")
-	storageClassName         = flag.String("storageClassName", "", "Name of StorageClass to opt-in PVs and PVCs for cleanup.")
+	kubeconfig               = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or kube-api-endpoint needs to be set if the provisioner is being run out of cluster.")
+	kubeApiEndpoint          = flag.String("kube-api-endpoint", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
+	resync                   = flag.Duration("resync", 10*time.Minute, "Duration, in minutes, of the resync interval of the controller.")
+	storageClassNames        = flag.StringSlice("storageclass-names", []string{}, "Comma separated list of names of StorageClasses to opt-in PVs and PVCs for cleanup.")
 	workerThreads            = flag.Uint("worker-threads", 10, "Number of controller worker threads.")
-	delay                    = flag.Duration("delay", 1*time.Minute, "How much time to wait after Node deletion for resource cleanup.")
-	stalePVDiscoveryInterval = flag.Duration("stalePVDiscoveryInterval", 10*time.Second, "The Deleter will look for an cleanup stale PVs periodically on this interval.")
+	pvcDeletionDelay         = flag.Duration("pvc-deletion-delay", 60*time.Second, "Duration, in seconds, to wait after Node deletion for PVC cleanup.")
+	stalePVDiscoveryInterval = flag.Duration("stale-pv-discovery-interval", 10*time.Second, "Duration, in seconds, the PV Deleter should wait between tries to clean up stale PVs.")
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 
 	ctx := context.Background()
 
-	config, err := buildConfig(*kubeconfig, *masterURL)
+	config, err := buildConfig(*kubeconfig, *kubeApiEndpoint)
 	if err != nil {
 		klog.Error(err, "Error building kubeconfig")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
@@ -45,16 +46,18 @@ func main() {
 
 	factory := informers.NewSharedInformerFactory(clientset, *resync)
 	pvInformer := factory.Core().V1().PersistentVolumes()
+	pvcInformer := factory.Core().V1().PersistentVolumeClaims()
 	nodeInformer := factory.Core().V1().Nodes()
 
 	cleanupController := controller.NewCleanupController(
 		clientset,
 		pvInformer,
+		pvcInformer,
 		nodeInformer,
-		*storageClassName,
-		*delay,
+		*storageClassNames,
+		*pvcDeletionDelay,
 		*stalePVDiscoveryInterval)
-	deleter := deleter.NewDeleter(clientset, pvInformer.Lister(), nodeInformer.Lister(), *storageClassName)
+	deleter := deleter.NewDeleter(clientset, pvInformer.Lister(), nodeInformer.Lister(), *storageClassNames)
 
 	factory.Start(ctx.Done())
 
@@ -68,11 +71,11 @@ func main() {
 	}
 }
 
-func buildConfig(kubeconfig string, masterURL string) (*rest.Config, error) {
+func buildConfig(kubeconfig string, kubeApiEndpoint string) (*rest.Config, error) {
 	// If kubeconfig was passed in then try to build from that
 	// since we may be out-of-cluster.
 	if kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+		return clientcmd.BuildConfigFromFlags(kubeApiEndpoint, kubeconfig)
 	}
 	// Otherwise we are in-cluster.
 	return rest.InClusterConfig()

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/controller"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/deleter"
 )
 
 // Command line flags
@@ -43,17 +44,24 @@ func main() {
 	}
 
 	factory := informers.NewSharedInformerFactory(clientset, *resync)
+	pvInformer := factory.Core().V1().PersistentVolumes()
+	nodeInformer := factory.Core().V1().Nodes()
 
 	cleanupController := controller.NewCleanupController(
 		clientset,
-		factory.Core().V1().PersistentVolumes(),
-		factory.Core().V1().Nodes(),
+		pvInformer,
+		nodeInformer,
 		*storageClassName,
 		*delay,
 		*stalePVDiscoveryInterval)
+	deleter := deleter.NewDeleter(clientset, pvInformer.Lister(), nodeInformer.Lister(), *storageClassName)
 
 	factory.Start(ctx.Done())
 
+	// Start Deleter
+	go deleter.Run(ctx, *stalePVDiscoveryInterval)
+
+	// Start controller
 	if err = cleanupController.Run(ctx, int(*workerThreads)); err != nil {
 		klog.Error(err, "Error running controller")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/controller"
+)
+
+// Command line flags
+var (
+	kubeconfig               = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Only required when running out of cluster.")
+	masterURL                = flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	resync                   = flag.Duration("resync", 10*time.Minute, "Resync interval of the controller.")
+	storageClassName         = flag.String("storageClassName", "", "Name of StorageClass to opt-in PVs and PVCs for cleanup.")
+	workerThreads            = flag.Uint("worker-threads", 10, "Number of controller worker threads.")
+	delay                    = flag.Duration("delay", 1*time.Minute, "How much time to wait after Node deletion for resource cleanup.")
+	stalePVDiscoveryInterval = flag.Duration("stalePVDiscoveryInterval", 10*time.Second, "The Deleter will look for an cleanup stale PVs periodically on this interval.")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	ctx := context.Background()
+
+	config, err := buildConfig(*kubeconfig, *masterURL)
+	if err != nil {
+		klog.Error(err, "Error building kubeconfig")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		klog.Error(err, "Error building kubernetes clientset")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+
+	factory := informers.NewSharedInformerFactory(clientset, *resync)
+
+	cleanupController := controller.NewCleanupController(
+		clientset,
+		factory.Core().V1().PersistentVolumes(),
+		factory.Core().V1().Nodes(),
+		*storageClassName,
+		*delay,
+		*stalePVDiscoveryInterval)
+
+	factory.Start(ctx.Done())
+
+	if err = cleanupController.Run(ctx, int(*workerThreads)); err != nil {
+		klog.Error(err, "Error running controller")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+	}
+}
+
+func buildConfig(kubeconfig string, masterURL string) (*rest.Config, error) {
+	// If kubeconfig was passed in then try to build from that
+	// since we may be out-of-cluster.
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	}
+	// Otherwise we are in-cluster.
+	return rest.InClusterConfig()
+}

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -34,7 +34,7 @@ import (
 // Command line flags
 var (
 	kubeconfig               = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or kube-api-endpoint needs to be set if the provisioner is being run out of cluster.")
-	kubeApiEndpoint          = flag.String("kube-api-endpoint", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
+	kubeAPIEndpoint          = flag.String("kube-api-endpoint", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
 	resync                   = flag.Duration("resync", 10*time.Minute, "Duration, in minutes, of the resync interval of the controller.")
 	storageClassNames        = flag.StringSlice("storageclass-names", []string{}, "Comma separated list of names of StorageClasses to opt-in PVs and PVCs for cleanup.")
 	workerThreads            = flag.Uint("worker-threads", 10, "Number of controller worker threads.")
@@ -48,7 +48,7 @@ func main() {
 
 	ctx := context.Background()
 
-	config, err := buildConfig(*kubeconfig, *kubeApiEndpoint)
+	config, err := buildConfig(*kubeconfig, *kubeAPIEndpoint)
 	if err != nil {
 		klog.Error(err, "Error building kubeconfig")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
@@ -87,11 +87,11 @@ func main() {
 	}
 }
 
-func buildConfig(kubeconfig string, kubeApiEndpoint string) (*rest.Config, error) {
+func buildConfig(kubeconfig string, kubeAPIEndpoint string) (*rest.Config, error) {
 	// If kubeconfig was passed in then try to build from that
 	// since we may be out-of-cluster.
 	if kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags(kubeApiEndpoint, kubeconfig)
+		return clientcmd.BuildConfigFromFlags(kubeAPIEndpoint, kubeconfig)
 	}
 	// Otherwise we are in-cluster.
 	return rest.InClusterConfig()

--- a/pkg/cleanup/controller/controller.go
+++ b/pkg/cleanup/controller/controller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/pkg/cleanup/controller/controller.go
+++ b/pkg/cleanup/controller/controller.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/deleter"
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 )
 
@@ -113,10 +112,6 @@ func (c *CleanupController) Run(ctx context.Context, workers int) error {
 
 	// Look for stale PVs and start timers for resource cleanup
 	c.startCleanupTimersIfNeeded()
-
-	// Run Deleter and block until channel is closed
-	deleter := deleter.NewDeleter(c.client, c.pvLister, c.nodeLister, c.storageClassName)
-	deleter.Run(ctx, c.stalePVDiscoveryInterval)
 
 	<-ctx.Done()
 	klog.Info("Shutting down workers")

--- a/pkg/cleanup/controller/controller.go
+++ b/pkg/cleanup/controller/controller.go
@@ -40,6 +40,9 @@ import (
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 )
 
+// CleanupController handles the deletion of PVCs that reference deleted Nodes.
+// Once a Node is deleted, if there was a PVC associated with that Node, a timer is started
+// for resource deletion. The PVC is deleted if the Node doesn't come back in a user-defined amount of time.
 type CleanupController struct {
 	client kubernetes.Interface
 
@@ -71,6 +74,8 @@ type CleanupController struct {
 	stalePVDiscoveryInterval time.Duration
 }
 
+// NewCleanupController creates a CleanupController that handles the
+// deletion of stale PVCs.
 func NewCleanupController(client kubernetes.Interface, pvInformer coreinformers.PersistentVolumeInformer, pvcInformer coreinformers.PersistentVolumeClaimInformer, nodeInformer coreinformers.NodeInformer, storageClassNames []string, pvcDeletionDelay time.Duration, stalePVDiscoveryInterval time.Duration) *CleanupController {
 	broadcaster := record.NewBroadcaster()
 	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("cleanup-controller")})

--- a/pkg/cleanup/controller/controller.go
+++ b/pkg/cleanup/controller/controller.go
@@ -66,7 +66,7 @@ func NewCleanupController(client kubernetes.Interface, pvInformer coreinformers.
 		pvQueue: workqueue.NewRateLimitingQueueWithConfig(
 			workqueue.DefaultControllerRateLimiter(),
 			workqueue.RateLimitingQueueConfig{
-				Name: "stalePVCQueue",
+				Name: "stalePVQueue",
 			}),
 		nodeLister:               nodeInformer.Lister(),
 		nodeListerSynced:         nodeInformer.Informer().HasSynced,

--- a/pkg/cleanup/controller/controller.go
+++ b/pkg/cleanup/controller/controller.go
@@ -1,0 +1,251 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cleanup/deleter"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+)
+
+type EntryPair struct {
+	nodeName string
+	pv       *v1.PersistentVolume
+}
+
+type CleanupController struct {
+	client kubernetes.Interface
+
+	// entryQueue is a rate-limited delayed queue. PVs and their corresponding Node are added
+	// as an EntryPair to this queue when the Node is deleted. The queue's delay allows to wait
+	// for the Node to come back up before cleaning up resources.
+	entryQueue workqueue.RateLimitingInterface
+
+	nodeLister       corelisters.NodeLister
+	nodeListerSynced cache.InformerSynced
+
+	pvLister       corelisters.PersistentVolumeLister
+	pvListerSynced cache.InformerSynced
+
+	eventRecorder record.EventRecorder
+	broadcaster   record.EventBroadcaster
+
+	// storageClassName is the name of the StorageClass that PVs and PVCs
+	// must belong to in order to be cleaned up.
+	storageClassName string
+
+	// delay is the amount of time to wait after Node deletion to cleanup resources.
+	delay time.Duration
+
+	// stalePVDiscoveryInterval is how often to scan for and delete PVs with affinity to a deleted Node.
+	stalePVDiscoveryInterval time.Duration
+}
+
+func NewCleanupController(client kubernetes.Interface, pvInformer coreinformers.PersistentVolumeInformer, nodeInformer coreinformers.NodeInformer, storageClassName string, delay time.Duration, stalePVDiscoveryInterval time.Duration) *CleanupController {
+	broadcaster := record.NewBroadcaster()
+	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("cleanup-controller")})
+
+	controller := &CleanupController{
+		client:           client,
+		storageClassName: storageClassName,
+		// Delayed queue with rate limiting
+		entryQueue: workqueue.NewRateLimitingQueueWithConfig(
+			workqueue.DefaultControllerRateLimiter(),
+			workqueue.RateLimitingQueueConfig{
+				Name: "stale",
+			}),
+		nodeLister:               nodeInformer.Lister(),
+		nodeListerSynced:         nodeInformer.Informer().HasSynced,
+		pvLister:                 pvInformer.Lister(),
+		pvListerSynced:           pvInformer.Informer().HasSynced,
+		eventRecorder:            eventRecorder,
+		broadcaster:              broadcaster,
+		delay:                    delay,
+		stalePVDiscoveryInterval: stalePVDiscoveryInterval,
+	}
+
+	// Set up event handler for when Nodes are deleted
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: controller.nodeDeleted,
+	})
+
+	return controller
+}
+
+// Run will start worker threads that try to process items off of the entryQueue, as well
+// as syncing informer caches and continuously running the Deleter.
+// It will block until the context gives a Done signal, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *CleanupController) Run(ctx context.Context, workers int) error {
+	defer utilruntime.HandleCrash()
+	defer c.entryQueue.ShutDown()
+
+	klog.Info("Starting to Run CleanupController")
+
+	c.broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: c.client.CoreV1().Events(v1.NamespaceAll)})
+	defer c.broadcaster.Shutdown()
+
+	klog.Info("Waiting for informer caches to sync")
+	// Wait for the caches to be synced before starting workers
+	if ok := cache.WaitForCacheSync(ctx.Done(), c.nodeListerSynced, c.pvListerSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.Infof("Starting workers, count: &d", workers)
+	// Launch workers to process
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	klog.Info("Started workers")
+
+	// Look for stale PVs and start timers for resource cleanup
+	c.startCleanupTimersIfNeeded()
+
+	// Run Deleter and block until channel is closed
+	deleter := deleter.NewDeleter(c.client, c.pvLister, c.nodeLister, c.storageClassName)
+	for {
+		select {
+		case <-ctx.Done():
+			klog.Info("CleanupController stopped")
+			return nil
+		default:
+			deleter.DeletePVs()
+			time.Sleep(c.stalePVDiscoveryInterval)
+		}
+	}
+}
+
+// runWorker is a long-running function that will continually call the
+// processNextWorkItem function in order to read and process a message on the entryQueue.
+func (c *CleanupController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+// processNextWorkItem will read a single work item off the entryQueue and
+// attempt to process it, by calling the syncHandler.
+func (c *CleanupController) processNextWorkItem(ctx context.Context) bool {
+	obj, shutdown := c.entryQueue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.entryQueue.Done(obj)
+
+	entryPair, ok := obj.(EntryPair)
+	if !ok {
+		// Item is invalid so we can forget it.
+		c.entryQueue.Forget(obj)
+		utilruntime.HandleError(fmt.Errorf("expected EntryPair in workqueue but got %#v", obj))
+		return true
+	}
+
+	err := c.syncHandler(ctx, entryPair)
+	if err != nil {
+		// An error occurred so re-add the item to the queue to work on later (has backoff to avoid
+		// hot-looping).
+		c.entryQueue.AddRateLimited(obj)
+		utilruntime.HandleError(fmt.Errorf("error syncing '%s': %s, requeuing", entryPair.pv.Name, err.Error()))
+		return true
+	}
+
+	c.entryQueue.Forget(obj)
+	return true
+}
+
+func (c *CleanupController) syncHandler(ctx context.Context, entryPair EntryPair) error {
+	nodeExists, err := common.NodeExists(c.nodeLister, entryPair.nodeName)
+	if err != nil {
+		return err
+	}
+
+	if nodeExists {
+		// Node is back up so cleanup is not needed.
+		return nil
+	}
+
+	pvClaimRef := entryPair.pv.Spec.ClaimRef
+	if pvClaimRef == nil {
+		return nil
+	}
+
+	err = c.client.CoreV1().PersistentVolumeClaims(pvClaimRef.Namespace).Delete(ctx, pvClaimRef.Name, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// The PVC could already be deleted by some other process, in
+			// which case we stop processing.
+			utilruntime.HandleError(fmt.Errorf("PVC '%s' in queue no longer exists", pvClaimRef.Name))
+			return nil
+		}
+		return err
+	}
+
+	klog.Infof("Deleted PVC '%s' that pointed to Node '%s'", pvClaimRef.Name, entryPair.nodeName)
+	return nil
+}
+
+func (c *CleanupController) nodeDeleted(obj interface{}) {
+	c.startCleanupTimersIfNeeded()
+}
+
+// startCleanupTimersIfNeeded enqueues any local PVs
+// with a given StorageClass and a NodeAffinity to a deleted Node.
+func (c *CleanupController) startCleanupTimersIfNeeded() {
+	pvs, err := c.pvLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error listing pvs: %s", err.Error()))
+		return
+	}
+
+	for _, pv := range pvs {
+		nodeName, ok := common.NodeAttachedToLocalPV(pv)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error getting node attached to pv: %s", pv))
+			continue
+		}
+
+		entry := &EntryPair{nodeName, pv}
+
+		shouldEnqueue, err := c.shouldEnqueueEntry(entry)
+		if err != nil {
+			utilruntime.HandleError(err)
+			continue
+		}
+
+		if shouldEnqueue {
+			klog.Infof("Starting timer for resource deletion, resource:%s, timer duration:%s", pv.Spec.ClaimRef, c.delay.String())
+			c.eventRecorder.Event(pv.Spec.ClaimRef, v1.EventTypeWarning, "ReferencedNodeDeleted", fmt.Sprintf("PVC is tied to a deleted Node. PVC will be cleaned up in %s if the Node doesn't come back", c.delay.String()))
+
+			c.entryQueue.AddAfter(*entry, c.delay)
+		}
+	}
+}
+
+// shouldEnqueuePV checks if a PV should be enqueued to the entryQueue.
+// The PV must be a local PV, have a given StorageClass, have a NodeAffinity
+// to a deleted Node, and have a PVC bound to it (otherwise there's nothing to clean up).
+func (c *CleanupController) shouldEnqueueEntry(entry *EntryPair) (bool, error) {
+	if !common.IsLocalPVWithStorageClass(entry.pv, c.storageClassName) || entry.pv.Spec.ClaimRef == nil {
+		return false, nil
+	}
+
+	exists, err := common.NodeExists(c.nodeLister, entry.nodeName)
+	return !exists && err == nil, err
+}

--- a/pkg/cleanup/controller/controller_test.go
+++ b/pkg/cleanup/controller/controller_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controller
 
 import (

--- a/pkg/cleanup/controller/controller_test.go
+++ b/pkg/cleanup/controller/controller_test.go
@@ -1,0 +1,302 @@
+package controller
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+)
+
+const (
+	defaultPVName               = "defaultPV"
+	nonExistentNodeName         = "non-existent-node"
+	testStorageClassName        = "test-storageclass"
+	defaultNodeName             = "defaultNode"
+	defaultPVCName              = "defaultPVC"
+	defaultNamespace            = "default"
+	alternativeStorageClassName = "alternative-storageclass"
+)
+
+var (
+	alwaysReady        = func() bool { return true }
+	noResyncPeriodFunc = func() time.Duration { return 0 }
+	localSource        = v1.PersistentVolumeSource{Local: &v1.LocalVolumeSource{}}
+	remoteSource       = v1.PersistentVolumeSource{
+		CSI: &v1.CSIPersistentVolumeSource{},
+	}
+)
+
+func TestCleanupController(t *testing.T) {
+	node := node()
+	pvc := pvc()
+
+	tests := []struct {
+		name string
+		// Objects to insert into fake kubeclient before the test starts.
+		initialObjects []runtime.Object
+		// PV object. This will automatically be added to initialObjects.
+		pv *v1.PersistentVolume
+		// PVC object. This will automatically be added to initialObjects.
+		pvc *v1.PersistentVolumeClaim
+		// Node object. This will automatically be added to initialObjects.
+		node                *v1.Node
+		expectedActions     []core.Action
+		nodeIsInitialObject bool // whether the Node exists when the controller starts
+		bringBackNode       bool // whether to bring up a Node in the middle of the test
+	}{
+		{
+			name: "pv with affinity to deleted node + node still deleted -> delete pvc",
+			pv:   pvWithPVCAndNode(pvc, node),
+			pvc:  pvc,
+			expectedActions: []core.Action{
+				deletePVCAction(pvc),
+			},
+		},
+		{
+			name:            "pv with affinity to deleted node + node brought back up -> don't delete pvc",
+			pv:              pvWithPVCAndNode(pvc, node),
+			pvc:             pvc,
+			node:            node,
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+			bringBackNode: true,
+		},
+		{
+			name:            "pv with affinity to node that exists -> don't delete pvc",
+			pv:              pvWithPVCAndNode(pvc, node),
+			pvc:             pvc,
+			node:            node,
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+			nodeIsInitialObject: true,
+		},
+		{
+			name:            "remote PV with affinity to deleted node -> don't delete pvc",
+			pv:              pvWithRemoteSource(pvWithPVCAndNode(pvc, node)),
+			pvc:             pvc,
+			node:            node,
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+		{
+			name:            "PV with wrong storageclass + affinity to deleted node -> don't delete pvc",
+			pv:              pvWithCustomStorageClass(pvWithPVCAndNode(pvc, node)),
+			pvc:             pvc,
+			node:            node,
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+		{
+			name: "PV with affinity to deleted node + PVC already deleted -> tries to delete PVC",
+			pv:   pvWithPVCAndNode(pvc, node),
+			expectedActions: []core.Action{
+				deletePVCAction(pvc),
+			},
+		},
+		{
+			name:            "PV without PVC -> do nothing",
+			pv:              pv(),
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Create initial data for client
+			if test.nodeIsInitialObject && test.node != nil {
+				test.initialObjects = append(test.initialObjects, test.node)
+			}
+			if test.pv != nil {
+				test.initialObjects = append(test.initialObjects, test.pv)
+			}
+			if test.pvc != nil {
+				test.initialObjects = append(test.initialObjects, test.pvc)
+			}
+
+			// Create client with initial data
+			client := fake.NewSimpleClientset(test.initialObjects...)
+
+			informers := informers.NewSharedInformerFactory(client, noResyncPeriodFunc())
+			pvInformer := informers.Core().V1().PersistentVolumes()
+			nodeInformer := informers.Core().V1().Nodes()
+
+			// Set delay for entryQueue. Delay only needed when the test
+			// adds back a deleted Node before the processing deadline.
+			var queueDelay time.Duration
+			if test.bringBackNode {
+				queueDelay = 3 * time.Second
+			} else {
+				queueDelay = time.Duration(0)
+			}
+
+			ctrl := NewCleanupController(client, pvInformer, nodeInformer, testStorageClassName, queueDelay, time.Duration(0))
+
+			// Populate the informers with initial objects so the controller can
+			// Get() and List() it.
+			for _, obj := range test.initialObjects {
+				switch obj.(type) {
+				case *v1.PersistentVolume:
+					pvInformer.Informer().GetStore().Add(obj)
+				case *v1.Node:
+					nodeInformer.Informer().GetStore().Add(obj)
+				case *v1.PersistentVolumeClaim:
+					// There is no PVC informer in the CleanupController
+					// so adding to a Store is not needed.
+					continue
+				default:
+					t.Fatalf("Unknown initalObject type: %+v", obj)
+				}
+			}
+
+			// Start test by simulating an event
+			ctrl.nodeDeleted(struct{}{})
+
+			if test.bringBackNode && test.node != nil {
+				nodeInformer.Informer().GetStore().Add(test.node)
+			}
+
+			// Process the controller queue until we get expected results
+			timeout := time.Now().Add(10 * time.Second)
+			queueWaitPeriod := time.Now().Add(queueDelay + 2*time.Second)
+			lastReportedActionCount := 0
+			for {
+				if time.Now().After(timeout) {
+					t.Errorf("Test %q: timed out", test.name)
+					break
+				}
+				if ctrl.entryQueue.Len() > 0 {
+					klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.entryQueue.Len())
+					ctrl.processNextWorkItem(context.TODO())
+				}
+				if ctrl.entryQueue.Len() > 0 {
+					// There is still some work in the queue, process it now
+					continue
+				}
+				currentActionCount := len(client.Actions())
+				if currentActionCount < len(test.expectedActions) {
+					// Do not log every wait, only when the action count changes.
+					if lastReportedActionCount < currentActionCount {
+						klog.V(5).Infof("Test %q: got %d actions out of %d, waiting for the rest", test.name, currentActionCount, len(test.expectedActions))
+						lastReportedActionCount = currentActionCount
+					}
+					// The test expected more to happen, wait for the actions.
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+				if !time.Now().After(queueWaitPeriod) {
+					// Since the queues are delayed, we give them a chance to
+					// add their items.
+					continue
+				}
+				break
+			}
+
+			actions := client.Actions()
+			for i, action := range actions {
+				print(action.GetVerb())
+				if len(test.expectedActions) < i+1 {
+					t.Errorf("Test %q: %d unexpected actions: %+v", test.name, len(actions)-len(test.expectedActions), actions[i:])
+					break
+				}
+
+				expectedAction := test.expectedActions[i]
+				if !reflect.DeepEqual(expectedAction, action) {
+					t.Errorf("Test %q: action %d\nExpected:\n%s\ngot:\n%s", test.name, i, expectedAction, action)
+				}
+			}
+
+			if len(test.expectedActions) > len(actions) {
+				t.Errorf("Test %q: %d additional expected actions", test.name, len(test.expectedActions)-len(actions))
+				for _, a := range test.expectedActions[len(actions):] {
+					t.Logf("    %+v", a)
+				}
+			}
+		})
+	}
+}
+
+func pv() *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultPVName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: localSource,
+			StorageClassName:       testStorageClassName,
+		},
+	}
+}
+
+func pvWithRemoteSource(pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.Spec.PersistentVolumeSource = remoteSource
+	return pv
+}
+
+func pvWithCustomStorageClass(pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.Spec.StorageClassName = alternativeStorageClassName
+	return pv
+}
+
+func pvWithPVCAndNode(pvc *v1.PersistentVolumeClaim, node *v1.Node) *v1.PersistentVolume {
+	pv := pv()
+	pv.Spec.ClaimRef = &v1.ObjectReference{
+		Kind:      "PersistentVolumeClaim",
+		Name:      pvc.Name,
+		Namespace: pvc.Namespace,
+	}
+	pv.Spec.NodeAffinity = &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      common.NodeLabelKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{node.Name},
+						},
+					},
+				},
+			},
+		},
+	}
+	return pv
+}
+
+func pvc() *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultPVCName,
+			Namespace: defaultNamespace,
+		},
+	}
+}
+
+func node() *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultNodeName,
+		},
+	}
+}
+
+func deletePVCAction(pvc *v1.PersistentVolumeClaim) core.DeleteActionImpl {
+	return core.NewDeleteAction(schema.GroupVersionResource{Version: "v1", Resource: "persistentvolumeclaims"}, pvc.Namespace, pvc.Name)
+}

--- a/pkg/cleanup/controller/controller_test.go
+++ b/pkg/cleanup/controller/controller_test.go
@@ -182,11 +182,11 @@ func TestCleanupController(t *testing.T) {
 					t.Errorf("Test %q: timed out", test.name)
 					break
 				}
-				if ctrl.entryQueue.Len() > 0 {
-					klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.entryQueue.Len())
+				if ctrl.pvQueue.Len() > 0 {
+					klog.V(5).Infof("Test %q: %d events queue, processing one", test.name, ctrl.pvQueue.Len())
 					ctrl.processNextWorkItem(context.TODO())
 				}
-				if ctrl.entryQueue.Len() > 0 {
+				if ctrl.pvQueue.Len() > 0 {
 					// There is still some work in the queue, process it now
 					continue
 				}

--- a/pkg/cleanup/deleter/deleter.go
+++ b/pkg/cleanup/deleter/deleter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cleanup/deleter/deleter.go
+++ b/pkg/cleanup/deleter/deleter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deleter
 
 import (

--- a/pkg/cleanup/deleter/deleter.go
+++ b/pkg/cleanup/deleter/deleter.go
@@ -52,6 +52,7 @@ func NewDeleter(client kubernetes.Interface, pvLister corelisters.PersistentVolu
 	}
 }
 
+// Run will delete stale PVs on a given interval until the given context is done.
 func (d *Deleter) Run(ctx context.Context, discoveryInterval time.Duration) {
 	for {
 		select {
@@ -65,7 +66,7 @@ func (d *Deleter) Run(ctx context.Context, discoveryInterval time.Duration) {
 	}
 }
 
-// Delete PVs will scan through PVs and delete those that are
+// DeletePVs will scan through PVs and delete those that are
 // local PVs with a StorageClass listed in storageClassNames and have an affinity to a deleted Node.
 func (d *Deleter) DeletePVs(ctx context.Context) {
 	pvs, err := d.pvLister.List(labels.Everything())

--- a/pkg/cleanup/deleter/deleter.go
+++ b/pkg/cleanup/deleter/deleter.go
@@ -1,0 +1,108 @@
+package deleter
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+)
+
+// Deleter handles cleanup of local PVs with an affinity to a deleted Node.
+// Only PVs with the passed-in storageClassName will be considered for cleanup.
+type Deleter struct {
+	client           kubernetes.Interface
+	pvLister         corelisters.PersistentVolumeLister
+	nodeLister       corelisters.NodeLister
+	storageClassName string
+}
+
+// NewDeleter creates a Deleter object to handle the deletion of local PVs
+// that use a given StorageClass and have an affinity to a deleted Node.
+func NewDeleter(client kubernetes.Interface, pvLister corelisters.PersistentVolumeLister, nodeLister corelisters.NodeLister, storageClassName string) *Deleter {
+	return &Deleter{
+		client:           client,
+		pvLister:         pvLister,
+		nodeLister:       nodeLister,
+		storageClassName: storageClassName,
+	}
+}
+
+// Delete PVs will scan through PVs and delete those that are
+// local PVs with a given StorageClass and have an affinity to a deleted Node.
+func (d *Deleter) DeletePVs() {
+	pvs, err := d.pvLister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error listing pvs: %s", err.Error()))
+		return
+	}
+
+	for _, pv := range pvs {
+		if !common.IsLocalPVWithStorageClass(pv, d.storageClassName) {
+			// Either isn't a local PV or doesn't have matching storage class.
+			continue
+		}
+
+		referencesDeletedNode, err := d.referencesNonExistentNode(pv)
+		if err != nil {
+			utilruntime.HandleError(err)
+			continue
+		}
+		if !referencesDeletedNode {
+			// PV's node is up so PV is not stale
+			continue
+		}
+
+		// PV is a stale object since it references a deleted Node.
+		// Therefore it can safely be deleted in the two following cases.
+		isReleasedWithDeleteReclaim := pv.Status.Phase == v1.VolumeReleased && pv.Spec.PersistentVolumeReclaimPolicy == v1.PersistentVolumeReclaimDelete
+		isAvailable := pv.Status.Phase == v1.VolumeAvailable
+		if isReleasedWithDeleteReclaim || isAvailable {
+			klog.Infof("Deleting PV that has NodeAffinity to deleted Node, pv: %s", pv.Name)
+			if err = d.deletePV(pv.Name); err != nil {
+				klog.Errorf("Error deleting PV: %s", pv.Name)
+			}
+		}
+	}
+}
+
+// referencesNonExistentNode returns true if the local PV has a NodeAffinity to
+// a deleted Node. An error is returned if the local PV's NodeAffinity
+// does not have the form:
+//
+//	nodeAffinity:
+//	  required:
+//	    nodeSelectorTerms:
+//	    - matchExpressions:
+//	      - key: kubernetes.io/hostname
+//	        operator: In
+//	        values:
+//	        - <node1>
+func (d *Deleter) referencesNonExistentNode(localPV *v1.PersistentVolume) (bool, error) {
+	nodeName, ok := common.NodeAttachedToLocalPV(localPV)
+	if !ok {
+		return false, fmt.Errorf("Error retrieving node")
+	}
+
+	exists, err := common.NodeExists(d.nodeLister, nodeName)
+	return !exists && err == nil, err
+}
+
+func (d *Deleter) deletePV(pvName string) error {
+	err := d.client.CoreV1().PersistentVolumes().Delete(context.TODO(), pvName, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			utilruntime.HandleError(fmt.Errorf("PV '%s' no longer exists", pvName))
+			return nil
+		}
+	}
+	return err
+}

--- a/pkg/cleanup/deleter/deleter_test.go
+++ b/pkg/cleanup/deleter/deleter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cleanup/deleter/deleter_test.go
+++ b/pkg/cleanup/deleter/deleter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deleter
 
 import (

--- a/pkg/cleanup/deleter/deleter_test.go
+++ b/pkg/cleanup/deleter/deleter_test.go
@@ -1,0 +1,215 @@
+package deleter
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+)
+
+const (
+	nonExistentNodeName         = "testNonExistentNodeName"
+	testNodeName                = "testNodeName"
+	testStorageClassName        = "testStorageClassName"
+	testPVName                  = "testPVName"
+	alternativeStorageClassName = "alternativeStorageClassName"
+)
+
+var (
+	alwaysReady        = func() bool { return true }
+	noResyncPeriodFunc = func() time.Duration { return 0 }
+	localSource        = v1.PersistentVolumeSource{Local: &v1.LocalVolumeSource{}}
+	remoteSource       = v1.PersistentVolumeSource{CSI: &v1.CSIPersistentVolumeSource{}}
+)
+
+func TestDeleter(t *testing.T) {
+	node := node()
+
+	tests := []struct {
+		name string
+		// Objects to insert into fake kubeclient before the test starts.
+		initialObjects []runtime.Object
+		// PV object. This will automatically be added to initialObjects.
+		pv *v1.PersistentVolume
+		// Node object. This will automatically be added to initialObjects.
+		node            *v1.Node
+		expectedActions []core.Action
+	}{
+		{
+			name: "released local pv with delete reclaim",
+			pv:   localPV(node, v1.VolumeReleased, v1.PersistentVolumeReclaimDelete),
+			expectedActions: []core.Action{
+				deletePVAction(localPV(node, v1.VolumeReleased, v1.PersistentVolumeReclaimDelete)),
+			},
+		},
+		{
+			name: "available local pv with delete reclaim",
+			pv:   localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete),
+			expectedActions: []core.Action{
+				deletePVAction(localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete)),
+			},
+		},
+		{
+			name: "available local pv with recycle reclaim",
+			pv:   localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRecycle),
+			expectedActions: []core.Action{
+				deletePVAction(localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRecycle)),
+			},
+		},
+		{
+			name: "available local pv with retain reclaim",
+			pv:   localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain),
+			expectedActions: []core.Action{
+				deletePVAction(localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain)),
+			},
+		},
+		{
+			name:            "local pv has wrong storage class name",
+			pv:              pvWithCustomStorageClass(localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain)),
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+		{
+			name:            "pv is not a local pv",
+			pv:              pvWithRemoteSource(localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain)), // change source to be remote
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+		{
+			name:            "local pv has affinity to node that still exists",
+			pv:              localPV(node, v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain),
+			node:            node,
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+		{
+			name:            "empty",
+			expectedActions: []core.Action{
+				// Intentionally left empty
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create initial data for client
+			if test.node != nil {
+				test.initialObjects = append(test.initialObjects, test.node)
+			}
+			if test.pv != nil {
+				test.initialObjects = append(test.initialObjects, test.pv)
+			}
+
+			// Create client with initial data
+			client := fake.NewSimpleClientset(test.initialObjects...)
+
+			informers := informers.NewSharedInformerFactory(client, noResyncPeriodFunc())
+			pvInformer := informers.Core().V1().PersistentVolumes()
+			nodeInformer := informers.Core().V1().Nodes()
+
+			deleter := NewDeleter(client, pvInformer.Lister(), nodeInformer.Lister(), testStorageClassName)
+
+			// Populate the informers with initial objects so the controller can
+			// Get() and List() it.
+			for _, obj := range test.initialObjects {
+				switch obj.(type) {
+				case *v1.PersistentVolume:
+					pvInformer.Informer().GetStore().Add(obj)
+				case *v1.Node:
+					nodeInformer.Informer().GetStore().Add(obj)
+				default:
+					t.Fatalf("Unknown initalObject type: %+v", obj)
+				}
+			}
+
+			// Start test by simulating an event.
+			deleter.DeletePVs()
+
+			actions := client.Actions()
+			for i, action := range actions {
+				print(action.GetVerb())
+				if len(test.expectedActions) < i+1 {
+					t.Errorf("Test %q: %d unexpected actions: %+v", test.name, len(actions)-len(test.expectedActions), actions[i:])
+					break
+				}
+
+				expectedAction := test.expectedActions[i]
+				if !reflect.DeepEqual(expectedAction, action) {
+					t.Errorf("Test %q: action %d\nExpected:\n%s\ngot:\n%s", test.name, i, expectedAction, action)
+				}
+			}
+
+			if len(test.expectedActions) > len(actions) {
+				t.Errorf("Test %q: %d additional expected actions", test.name, len(test.expectedActions)-len(actions))
+				for _, a := range test.expectedActions[len(actions):] {
+					t.Logf("    %+v", a)
+				}
+			}
+		})
+	}
+}
+
+func pvWithRemoteSource(pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.Spec.PersistentVolumeSource = remoteSource
+	return pv
+}
+
+func pvWithCustomStorageClass(pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.Spec.StorageClassName = alternativeStorageClassName
+	return pv
+}
+
+func localPV(node *v1.Node, phase v1.PersistentVolumePhase, reclaimPolicy v1.PersistentVolumeReclaimPolicy) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testPVName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: localSource,
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      common.NodeLabelKey,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{node.Name},
+								},
+							},
+						},
+					},
+				},
+			},
+			PersistentVolumeReclaimPolicy: reclaimPolicy,
+			StorageClassName:              testStorageClassName,
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func node() *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+		},
+	}
+}
+
+func deletePVAction(pv *v1.PersistentVolume) core.DeleteActionImpl {
+	return core.NewDeleteAction(schema.GroupVersionResource{Version: "v1", Resource: "persistentvolumes"}, pv.Namespace, pv.Name)
+}

--- a/pkg/cleanup/deleter/deleter_test.go
+++ b/pkg/cleanup/deleter/deleter_test.go
@@ -1,6 +1,7 @@
 package deleter
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -135,11 +136,10 @@ func TestDeleter(t *testing.T) {
 			}
 
 			// Start test by simulating an event.
-			deleter.DeletePVs()
+			deleter.DeletePVs(context.TODO())
 
 			actions := client.Actions()
 			for i, action := range actions {
-				print(action.GetVerb())
 				if len(test.expectedActions) < i+1 {
 					t.Errorf("Test %q: %d unexpected actions: %+v", test.name, len(actions)-len(test.expectedActions), actions[i:])
 					break
@@ -154,7 +154,7 @@ func TestDeleter(t *testing.T) {
 			if len(test.expectedActions) > len(actions) {
 				t.Errorf("Test %q: %d additional expected actions", test.name, len(test.expectedActions)-len(actions))
 				for _, a := range test.expectedActions[len(actions):] {
-					t.Logf("    %+v", a)
+					t.Logf("additional action: %+v", a)
 				}
 			}
 		})

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -511,17 +511,25 @@ func NodeExists(nodeLister corelisters.NodeLister, nodeName string) (bool, error
 //	        - <node1>
 func NodeAttachedToLocalPV(pv *v1.PersistentVolume) (string, bool) {
 	nodeNames := volumeUtil.GetLocalPersistentVolumeNodeNames(pv)
-	if nodeNames == nil || len(nodeNames) == 0 {
+	// We assume that there should only be one matching node.
+	if nodeNames == nil || len(nodeNames) != 1 {
 		return "", false
 	}
-	// We assume that there should only be one matching node.
 	return nodeNames[0], true
 }
 
-// IsLocalPVWithStorageClass checks that a PV is a local PV with a specific StorageClass name.
-func IsLocalPVWithStorageClass(pv *v1.PersistentVolume, storageClassName string) bool {
-	if pv.Spec.Local == nil || pv.Spec.StorageClassName != storageClassName {
+// IsLocalPVWithStorageClass checks that a PV is a local PV that belongs to any of the passed in StorageClasses.
+func IsLocalPVWithStorageClass(pv *v1.PersistentVolume, storageClassNames []string) bool {
+	if pv.Spec.Local == nil {
 		return false
 	}
-	return true
+
+	// Return true if the PV's StorageClass matches any of the passed in
+	for _, storageClassName := range storageClassNames {
+		if pv.Spec.StorageClassName == storageClassName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -509,7 +509,7 @@ func NodeExists(nodeLister corelisters.NodeLister, nodeName string) (bool, error
 //	        operator: In
 //	        values:
 //	        - <node1>
-func NodeAttachedToLocalPV(pv *v1.PersistentVolume) (nodeName string, ok bool) {
+func NodeAttachedToLocalPV(pv *v1.PersistentVolume) (string, bool) {
 	nodeNames := volumeUtil.GetLocalPersistentVolumeNodeNames(pv)
 	if nodeNames == nil || len(nodeNames) == 0 {
 		return "", false

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -34,13 +34,16 @@ import (
 	"hash/fnv"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
+	volumeUtil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/utils/mount"
 )
 
@@ -483,4 +486,42 @@ func GetVolumeMode(volUtil util.VolumeUtil, fullPath string) (v1.PersistentVolum
 		return "", fmt.Errorf("Directory check for %q failed: %s", fullPath, errdir)
 	}
 	return "", fmt.Errorf("Block device check for %q failed: %s", fullPath, errblk)
+}
+
+// NodeExists checks to see if a Node exists in the Indexer of a NodeLister.
+func NodeExists(nodeLister corelisters.NodeLister, nodeName string) (bool, error) {
+	_, err := nodeLister.Get(nodeName)
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// NodeAttachedToLocalPV gets the name of the Node that a local PV has a NodeAffinity to.
+// It assumes that there should be only one matching Node for a local PV and that
+// the local PV follows the form:
+//
+//	nodeAffinity:
+//	  required:
+//	    nodeSelectorTerms:
+//	    - matchExpressions:
+//	      - key: kubernetes.io/hostname
+//	        operator: In
+//	        values:
+//	        - <node1>
+func NodeAttachedToLocalPV(pv *v1.PersistentVolume) (nodeName string, ok bool) {
+	nodeNames := volumeUtil.GetLocalPersistentVolumeNodeNames(pv)
+	if nodeNames == nil || len(nodeNames) == 0 {
+		return "", false
+	}
+	// We assume that there should only be one matching node.
+	return nodeNames[0], true
+}
+
+// IsLocalPVWithStorageClass checks that a PV is a local PV with a specific StorageClass name.
+func IsLocalPVWithStorageClass(pv *v1.PersistentVolume, storageClassName string) bool {
+	if pv.Spec.Local == nil || pv.Spec.StorageClassName != storageClassName {
+		return false
+	}
+	return true
 }

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -551,8 +551,11 @@ func TestNodeAttachedToLocalPV(t *testing.T) {
 
 	for _, test := range tests {
 		nodeName, ok := NodeAttachedToLocalPV(test.pv)
-		if nodeName != test.expectedNodeName || ok != test.expectedStatus {
-			t.Errorf("test: %s, nodeName: %s, expectedNodeName: %s, status: %t, expectedStaus: %t", test.name, nodeName, test.expectedNodeName, ok, test.expectedStatus)
+		if ok != test.expectedStatus {
+			t.Errorf("test: %s, status: %t, expectedStaus: %t", test.name, ok, test.expectedStatus)
+		}
+		if nodeName != test.expectedNodeName {
+			t.Errorf("test: %s, nodeName: %s, expectedNodeName: %s", test.name, nodeName, test.expectedNodeName)
 		}
 	}
 }

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -30,7 +30,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 )
 
@@ -472,4 +475,164 @@ func TestGetVolumeMode(t *testing.T) {
 			t.Errorf("volumeUtil: %v, fullPath: %v, expected mode: %v, got mode: %v, expected error: %v, got error: %v", test.volumeUtil, test.fullPath, test.expected, mode, test.expectedErr, err)
 		}
 	}
+}
+
+func TestNodeExists(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+	}
+
+	tests := []struct {
+		nodeAdded *v1.Node
+		// Required.
+		nodeQueried    *v1.Node
+		expectedResult bool
+	}{
+		{
+			nodeAdded:      node,
+			nodeQueried:    node,
+			expectedResult: true,
+		},
+		{
+			nodeQueried:    node,
+			expectedResult: false,
+		},
+	}
+
+	for _, test := range tests {
+		client := fake.NewSimpleClientset()
+		informers := informers.NewSharedInformerFactory(client, time.Duration(0))
+		nodeInformer := informers.Core().V1().Nodes()
+
+		if test.nodeAdded != nil {
+			nodeInformer.Informer().GetStore().Add(test.nodeAdded)
+		}
+
+		exists, err := NodeExists(nodeInformer.Lister(), test.nodeQueried.Name)
+		if err != nil {
+			t.Errorf("Got unexpected error: %s", err.Error())
+		}
+		if exists != test.expectedResult {
+			t.Errorf("expected result: %t, actual: %t", test.expectedResult, exists)
+		}
+	}
+}
+
+func TestNodeAttachedToLocalPV(t *testing.T) {
+	nodeName := "testNodeName"
+
+	tests := []struct {
+		name             string
+		pv               *v1.PersistentVolume
+		expectedNodeName string
+		expectedStatus   bool
+	}{
+		{
+			name:             "NodeAffinity will all necessary fields",
+			pv:               withNodeAffinity(pv(), nodeName, NodeLabelKey),
+			expectedNodeName: nodeName,
+			expectedStatus:   true,
+		},
+		{
+			name:             "empty Values array",
+			pv:               removeAllNodeNames(withNodeAffinity(pv(), nodeName, NodeLabelKey)),
+			expectedNodeName: "",
+			expectedStatus:   false,
+		},
+		{
+			name:             "wrong node label key",
+			pv:               withNodeAffinity(pv(), nodeName, "wrongLabel"),
+			expectedNodeName: "",
+			expectedStatus:   false,
+		},
+	}
+
+	for _, test := range tests {
+		nodeName, ok := NodeAttachedToLocalPV(test.pv)
+		if nodeName != test.expectedNodeName || ok != test.expectedStatus {
+			t.Errorf("test: %s, nodeName: %s, expectedNodeName: %s, status: %t, expectedStaus: %t", test.name, nodeName, test.expectedNodeName, ok, test.expectedStatus)
+		}
+	}
+}
+
+func TestIsLocalPVWithStorageClass(t *testing.T) {
+	tests := []struct {
+		name             string
+		pv               *v1.PersistentVolume
+		storageClassName string
+		expected         bool
+	}{
+		{
+			name: "local PV with matching StorageClass",
+			pv: &v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{Local: &v1.LocalVolumeSource{}},
+					StorageClassName:       "testStorageClassName",
+				},
+			},
+			storageClassName: "testStorageClassName",
+			expected:         true,
+		},
+		{
+			name: "local PV without matching StorageClass",
+			pv: &v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{Local: &v1.LocalVolumeSource{}},
+					StorageClassName:       "wrongName",
+				},
+			},
+			storageClassName: "testStorageClassName",
+			expected:         false,
+		},
+		{
+			name: "non-local PV with matching StorageClass",
+			pv: &v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{},
+					StorageClassName:       "testStorageClassName",
+				},
+			},
+			storageClassName: "testStorageClassName",
+			expected:         false,
+		},
+	}
+
+	for _, test := range tests {
+		result := IsLocalPVWithStorageClass(test.pv, test.storageClassName)
+		if result != test.expected {
+			t.Errorf("name: %s, pv: %v, storageClassName: %s, expected result: %t, actual: %t", test.name, test.pv, test.storageClassName, test.expected, result)
+		}
+	}
+}
+
+func pv() *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		Spec: v1.PersistentVolumeSpec{},
+	}
+}
+
+func withNodeAffinity(pv *v1.PersistentVolume, nodeName string, nodeLabelKey string) *v1.PersistentVolume {
+	pv.Spec.NodeAffinity = &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      nodeLabelKey,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{nodeName},
+						},
+					},
+				},
+			},
+		},
+	}
+	return pv
+}
+
+func removeAllNodeNames(pv *v1.PersistentVolume) *v1.PersistentVolume {
+	pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0].Values = []string{}
+	return pv
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR allows for workloads using Local PVs (backed by ephemeral disks) to automatically recover from Node deletion. It does so by cleaning up local PVs and PVCs associated with deleted Nodes. The cleanup is configurable in that the controller will wait for a user-defined amount of time on Node deletion to start cleanup. Further, the controller will only clean up resources associated with a user-defined StorageClass to allow for this feature to be opt-in.

This feature is needed since when Nodes are deleted while having a Local PV mounted on them, Pods using the Local PV become stuck since they are tied to PVC and PV objects that reference a deleted Node. Deleting the PVC allows the Pod to get rescheduled and deleting the stale PVs reduces clutter in the apiserver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #202 

**Special notes for your reviewer**:


**Release note**:
```release-note
Optional controller to automatically clean up stale PV/PVC objects when a Node is deleted
```
