### PR TITLE
feat(helm): Added volume support for init containers

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -199,6 +199,7 @@ provisioner chart and their default values.
 | common.setPVOwnerRef                         | If set to true, PVs are set to be dependents of the owner Node.                                       | bool     | `false`                                                    |
 | common.mountDevVolume                        | If set to false, the node's `/dev` path will not be mounted into containers.                          | bool     | `true`                                                     |
 | common.labelsForPV                           | Map of label key-value pairs to apply to the PVs created by the provisioner.                          | map      | `-`                                                        |
+| common.additionalVolumes                     | List of additional volumes to create.                                                  | list      | `-`                                                        |
 | classes.[n].name                             | StorageClass name.                                                                                    | str      | `-`                                                        |
 | classes.[n].hostDir                          | Path on the host where local volumes of this storage class are mounted under.                         | str      | `-`                                                        |
 | classes.[n].mountDir                         | Optionally specify mount path of local volumes. By default, we use same path as hostDir in container. | str      | `-`                                                        |
@@ -221,6 +222,8 @@ provisioner chart and their default values.
 | daemonset.resources                          | Map of resource request and limits to be applied to the Provisioner Daemonset.                        | map      | `-`                                                 |
 | daemonset.affinity                           | List of affinity to be applied to the provisioner Daemonset.                                                 | list     | `-`
 | daemonset.privileged                         | If set to false, containers created by the Provisioner Daemonset will run without extra privileges.   | bool     | `true`                                                     |
+| daemonset.initContainers                     |  Init containers.                                                | list       | `-` |
+| daemonset.additionalVolumeMounts                     |  Additional volumes to mount to the default container, the volumes should be defined by common. | list       | `-` |
 | serviceMonitor.enabled                       | If set to true, Prometheus servicemonitor will be applied                                             | bool     | `false`                                                    |
 | serviceMonitor.interval                      | Interval at which Prometheus scrapes the provisioner                                                  | str      | `10s`                                                      |
 | serviceMonitor.namespace                     | The namespace Prometheus servicemonitor will be installed                                             | str      | `.Release.Namespace`                                       |

--- a/helm/provisioner/Chart.yaml
+++ b/helm/provisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: local-static-provisioner
 description: Helm chart for the SIG Storage Local Volume Static Provisioner.
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: 2.5.0
 keywords:
   - storage

--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -92,6 +92,9 @@ spec:
               mountPath: {{ $classConfig.mountDir | default $classConfig.hostDir }}
               mountPropagation: HostToContainer
             {{- end }}
+            {{- with .Values.daemonset.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: provisioner-config
           configMap:
@@ -106,8 +109,11 @@ spec:
           hostPath:
             path: {{ $classConfig.hostDir }}
         {{- end }}
-        {{- range $name, $path := .Values.daemonset.additionalHostPathVolumes }}
+        {{- range $name, $path := .Values.common.additionalHostPathVolumes }}
         - name: {{ quote $name }}
           hostPath:
             path: {{ quote $path }}
+        {{- end }}
+        {{- with .Values.common.additionalVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/provisioner/templates/daemonset_windows.yaml
+++ b/helm/provisioner/templates/daemonset_windows.yaml
@@ -103,6 +103,9 @@ spec:
               mountPath: \\.\pipe\csi-proxy-volume-v1beta2
             - name: csi-proxy-filesystem-v1beta2
               mountPath: \\.\pipe\csi-proxy-filesystem-v1beta2
+            {{- with .Values.daemonset.additionalVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: csi-proxy-volume-v1
           hostPath:
@@ -139,8 +142,11 @@ spec:
           hostPath:
             path: {{ $classConfig.hostDir }}
         {{- end }}
-        {{- range $name, $path := .Values.daemonset.additionalHostPathVolumes }}
+        {{- range $name, $path := .Values.common.additionalHostPathVolumes }}
         - name: {{ quote $name }}
           hostPath:
             path: {{ quote $path }}
+        {{- end }}
+        {{- with .Values.common.additionalVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -60,6 +60,11 @@ common:
   #
   #labelsForPV:
   #  pv-labels: can-be-selected
+  #
+  # Additional volumes to create, for the default container and init containers
+  # to consume
+  #
+  additionalVolumes: []
 #
 # Configure storage classes.
 #
@@ -164,9 +169,16 @@ daemonset:
   #
   # If set to false, containers created by the Provisioner Daemonset will run without extra privileges.
   privileged: true
+  #
   # Any init containers can be configured here.
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  #
   initContainers: []
+  #
+  # Additional volumes to mount to the default container, the volumes should be
+  # defined by common.additionalVolumes
+  #
+  additionalVolumeMounts: []
 #
 # Configure Prometheus monitoring
 #


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for providing volumes to init containers, specifically for the use case adding a script via a ConfigMap. This is done via the addition of `additionalVolumes` & `additionalVolumeMounts` inputs which allow for the addition of pod volumes and also support mounting extra volumes to the default container (mainly for consistency).

It also fixes a chart typo in DaemonSet templates for the `additionalHostPathVolumes` which wouldn't have worked as 
 (not) documented. I would also suggest that the `additionalHostPathVolumes` be deprecated as the new `additionalVolumes` input is more flexible and idiomatic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note

```
