### PR TITLE
Add multi-arch manifest for node cleanup controller

### DIFF
--- a/cmd/node-cleanup/Dockerfile.Windows
+++ b/cmd/node-cleanup/Dockerfile.Windows
@@ -1,0 +1,25 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG OSVERSION
+FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
+LABEL description="Local Volume Provisioner Node Cleanup Controller"
+
+ARG OS=windows
+ARG ARCH=amd64
+ARG binary=./_output/${OS}/${ARCH}/local-volume-node-cleanup.exe
+COPY ${binary} main.exe
+
+USER ContainerAdministrator
+ENTRYPOINT ["/main.exe"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

Adds multi-arch manifest for cleanup controller release to support Linux architectures and Windows.

**Release note**:
```release-note
NONE
```
