### PR TITLE
Bump default helm chart image to v2.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/prometheus/client_golang v1.14.0
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/sys v0.6.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.3
@@ -80,7 +81,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/cobra v1.6.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.7 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.7 // indirect
@@ -148,6 +148,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.27.3
 	k8s.io/cri-api => k8s.io/cri-api v0.27.3
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.3
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.3
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.27.3
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.3
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.3

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-- Helm Chart values flattened when possible (#393, @mauriciopoppe)
+- Helm Chart values flattened when possible ([#393](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/393), [@mauriciopoppe](https://github.com/mauriciopoppe))
   - Flattened top level `common` dictionary, all the keys are now at the top level.
   - Flattened top level `daemonset` dictionary, all the keys are now at the top level.
 - `rbac.pspEnabled` removed
@@ -10,6 +10,5 @@
 
 ### Features
 
-- Add enableWindows helm chart value to control the deployment of Windows manifests (#388, @jennwah)
-- Helm chart v1.0.0 uses registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
-  Add field .Values.daemonset.nodeSelectorWindows to the helm chart. (#353, @mauriciopoppe)
+- Add enableWindows helm chart value to control the deployment of Windows manifests ([#388](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/388), [@jennwah](https://github.com/jennwah))
+- Add support for additional volumes ([#401](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/401), [@stevehipwell](https://github.com/stevehipwell))

--- a/helm/generated_examples/additional-volumes.yaml
+++ b/helm/generated_examples/additional-volumes.yaml
@@ -122,7 +122,7 @@ spec:
             name: signal
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -135,7 +135,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-affinity.yaml
+++ b/helm/generated_examples/baremetal-affinity.yaml
@@ -131,7 +131,7 @@ spec:
                 - localssd
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -144,7 +144,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-cleanbyjobs.yaml
+++ b/helm/generated_examples/baremetal-cleanbyjobs.yaml
@@ -160,7 +160,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -173,7 +173,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-default-storage.yaml
+++ b/helm/generated_examples/baremetal-default-storage.yaml
@@ -120,7 +120,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -133,7 +133,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-nodeselector.yaml
+++ b/helm/generated_examples/baremetal-nodeselector.yaml
@@ -123,7 +123,7 @@ spec:
         localVolume: present
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -136,7 +136,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-priority-critical.yaml
+++ b/helm/generated_examples/baremetal-priority-critical.yaml
@@ -122,7 +122,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -135,7 +135,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-priority-noncritical.yaml
+++ b/helm/generated_examples/baremetal-priority-noncritical.yaml
@@ -122,7 +122,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -135,7 +135,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-prometheus.yaml
+++ b/helm/generated_examples/baremetal-prometheus.yaml
@@ -142,7 +142,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -155,7 +155,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-resyncperiod.yaml
+++ b/helm/generated_examples/baremetal-resyncperiod.yaml
@@ -121,7 +121,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -134,7 +134,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -125,7 +125,7 @@ spec:
           key: node-role.kubernetes.io/master
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -138,7 +138,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-with-resource-limits.yaml
+++ b/helm/generated_examples/baremetal-with-resource-limits.yaml
@@ -121,7 +121,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           resources:
@@ -142,7 +142,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-without-rbac.yaml
+++ b/helm/generated_examples/baremetal-without-rbac.yaml
@@ -74,7 +74,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -87,7 +87,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal.yaml
+++ b/helm/generated_examples/baremetal.yaml
@@ -121,7 +121,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -134,7 +134,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/eks-nvme-ssd.yaml
+++ b/helm/generated_examples/eks-nvme-ssd.yaml
@@ -117,7 +117,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -130,7 +130,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce-retain.yaml
+++ b/helm/generated_examples/gce-retain.yaml
@@ -135,7 +135,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -148,7 +148,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce.yaml
+++ b/helm/generated_examples/gce.yaml
@@ -135,7 +135,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -148,7 +148,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
+++ b/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
@@ -118,7 +118,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -131,7 +131,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gke.yaml
+++ b/helm/generated_examples/gke.yaml
@@ -118,7 +118,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: provisioner
-          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+          image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           securityContext:
             privileged: true
           env:
@@ -131,7 +131,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+            value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/provisioner/Chart.yaml
+++ b/helm/provisioner/Chart.yaml
@@ -3,7 +3,7 @@ name: local-static-provisioner
 description: Helm chart for the SIG Storage Local Volume Static Provisioner.
 type: application
 version: 1.0.0
-appVersion: 2.5.0
+appVersion: 2.6.0
 keywords:
   - storage
   - local

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -91,7 +91,7 @@ podAnnotations: {}
 podLabels: {}
 
 # Defines Provisioner's image name including container registry.
-image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.5.0
+image: registry.k8s.io/sig-storage/local-volume-provisioner:v2.6.0
 
 # Defines Image download policy, see kubernetes documentation for available values.
 # imagePullPolicy: Always

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1468,6 +1468,7 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => k8s.io/controller-manager v0.27.3
 # k8s.io/cri-api => k8s.io/cri-api v0.27.3
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.3
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.3
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.27.3
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.3
 # k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.3


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:
Bump the helm chart image to v2.6.0 in preparation for the helm chart v2.0.0 release.

**Release note**:
```release-note
NONE
```

/cc @msau42 