### PR TITLE
fix: do not try to get node for non-local PVs

### DIFF
--- a/pkg/node-cleanup/controller/controller.go
+++ b/pkg/node-cleanup/controller/controller.go
@@ -260,6 +260,10 @@ func (c *CleanupController) startCleanupTimersIfNeeded() {
 	}
 
 	for _, pv := range pvs {
+		if !common.IsLocalPVWithStorageClass(pv, c.storageClassNames) {
+			continue
+		}
+
 		nodeName, ok := common.NodeAttachedToLocalPV(pv)
 		if !ok {
 			klog.Errorf("error getting node attached to pv: %s", pv)
@@ -285,7 +289,7 @@ func (c *CleanupController) startCleanupTimersIfNeeded() {
 // The PV must be a local PV, have a StorageClass present in the list of storageClassNames, have a NodeAffinity
 // to a deleted Node, and have a PVC bound to it (otherwise there's nothing to clean up).
 func (c *CleanupController) shouldEnqueueEntry(pv *v1.PersistentVolume, nodeName string) (bool, error) {
-	if !common.IsLocalPVWithStorageClass(pv, c.storageClassNames) || pv.Spec.ClaimRef == nil {
+	if pv.Spec.ClaimRef == nil {
 		return false, nil
 	}
 


### PR DESCRIPTION
Remote source PVs (like AWS EBS) do not have a node associated with them.
This commit skips the node lookup for such PVs.

Otherwise, the controller logs the following error for each remote PV:

```bash
error getting node attached to pv: &PersistentVolume{...}
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

This commit skips the node lookup for non-local PVs, thereby preventing unnecessary errors in the logs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
NONE
```
