### PR TITLE
Recreate PVC based of pending pods if their PVC storage class matches…

### DIFF
--- a/cmd/node-cleanup/main.go
+++ b/cmd/node-cleanup/main.go
@@ -50,6 +50,8 @@ var (
 	stalePVDiscoveryInterval = flag.Duration("stale-pv-discovery-interval", 10*time.Second, "Duration, in seconds, the PV Deleter should wait between tries to clean up stale PVs.")
 	listenAddress            = flag.String("listen-address", ":8080", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`).")
 	metricsPath              = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed.")
+	recreatePvc              = flag.Bool("recreate-pvc", true, "Recreate the PVC after deleting it.")
+	namespacesToWatch        = flag.StringSlice("namespaces-to-watch", []string{}, "Comma separated list of namespaces to watch for Pods with missing PVCs to recreate.")
 )
 
 func main() {
@@ -83,7 +85,7 @@ func main() {
 		*storageClassNames,
 		*pvcDeletionDelay,
 		*stalePVDiscoveryInterval)
-	deleter := deleter.NewDeleter(clientset, pvInformer.Lister(), nodeInformer.Lister(), *storageClassNames)
+	deleter := deleter.NewDeleter(clientset, pvInformer.Lister(), nodeInformer.Lister(), *storageClassNames, *recreatePvc, *namespacesToWatch)
 
 	factory.Start(ctx.Done())
 

--- a/pkg/metrics/node-cleanup/metrics.go
+++ b/pkg/metrics/node-cleanup/metrics.go
@@ -62,4 +62,20 @@ var (
 			Help:      "Total number of persistent volume claim delete failed attempts.",
 		},
 	)
+	// PersistentVolumeClaimRecreateFailedTotal is used to collect accumulated count of persistent volume claim recreation failed attempts.
+	PersistentVolumeClaimRecreateFailedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeNodeCleanupSubsystem,
+			Name:      "persistentvolumeclaim_recreate_failed_total",
+			Help:      "Total number of persistent volume claim recreation failed attempts.",
+		},
+	)
+	// PersistentVolumeClaimRecreateSuccessTotal is used to collect accumulated count of persistent volume claim recreation successes.
+	PersistentVolumeClaimRecreateSuccessTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeNodeCleanupSubsystem,
+			Name:      "persistentvolumeclaim_recreate_success_total",
+			Help:      "Total number of persistent volume claim recreation successes.",
+		},
+	)
 )

--- a/pkg/node-cleanup/controller/controller.go
+++ b/pkg/node-cleanup/controller/controller.go
@@ -273,7 +273,7 @@ func (c *CleanupController) startCleanupTimersIfNeeded() {
 		}
 
 		if shouldEnqueue {
-			klog.Infof("Starting timer for resource deletion, resource:%s, timer duration: %s", pv.Spec.ClaimRef, c.pvcDeletionDelay.String())
+			klog.Infof("Starting timer for resource deletion, resource:%s, timer duration: %s, node: %s", pv.Spec.ClaimRef, c.pvcDeletionDelay.String(), nodeName)
 			c.eventRecorder.Event(pv.Spec.ClaimRef, v1.EventTypeWarning, "ReferencedNodeDeleted", fmt.Sprintf("PVC is tied to a deleted Node. PVC will be cleaned up in %s if the Node doesn't come back", c.pvcDeletionDelay.String()))
 
 			c.pvQueue.AddAfter(pv.Name, c.pvcDeletionDelay)

--- a/pkg/node-cleanup/deleter/deleter.go
+++ b/pkg/node-cleanup/deleter/deleter.go
@@ -40,16 +40,22 @@ type Deleter struct {
 	pvLister          corelisters.PersistentVolumeLister
 	nodeLister        corelisters.NodeLister
 	storageClassNames []string
+	namespacesToWatch []string
+
+	// When recreatePvc is true, PVCs are recreated after deleting them
+	recreatePvc bool
 }
 
 // NewDeleter creates a Deleter object to handle the deletion of local PVs
 // that have an affinity to a deleted Node and have a StorageClass listed in storageClassNames.
-func NewDeleter(client kubernetes.Interface, pvLister corelisters.PersistentVolumeLister, nodeLister corelisters.NodeLister, storageClassNames []string) *Deleter {
+func NewDeleter(client kubernetes.Interface, pvLister corelisters.PersistentVolumeLister, nodeLister corelisters.NodeLister, storageClassNames []string, recreatePvc bool, namespacesToWatch []string) *Deleter {
 	return &Deleter{
 		client:            client,
 		pvLister:          pvLister,
 		nodeLister:        nodeLister,
 		storageClassNames: storageClassNames,
+		recreatePvc:       recreatePvc,
+		namespacesToWatch: namespacesToWatch,
 	}
 }
 
@@ -110,6 +116,15 @@ func (d *Deleter) DeletePVs(ctx context.Context) {
 			cleanupmetrics.PersistentVolumeDeleteTotal.WithLabelValues(string(phase)).Inc()
 		}
 	}
+
+	if d.recreatePvc {
+		klog.Infof("PVC recreation is turned on, checking pending pods with non existent PVCs...")
+		err = d.recreatePVC(ctx)
+		if err != nil {
+			cleanupmetrics.PersistentVolumeClaimRecreateFailedTotal.Inc()
+			klog.Errorf("failed to recreated pvc: %v", err)
+		}
+	}
 }
 
 // referencesNonExistentNode returns true if the local PV has a NodeAffinity to
@@ -141,4 +156,73 @@ func (d *Deleter) deletePV(ctx context.Context, pvName string) error {
 		return nil
 	}
 	return err
+}
+
+// recreatePVC recreates the PVC with the given name and namespace
+// and returns nil if the operation was successful or if the PVC already exists
+func (d *Deleter) recreatePVC(ctx context.Context) error {
+	// list pods by namespace
+	for _, namespace := range d.namespacesToWatch {
+		klog.Infof("Looking for non existent PVCs keeping pods pending in namespace %q", namespace)
+		podsInNamespace, err := d.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			klog.Errorf("failed to list pods in namespace %q: %v", namespace, err)
+			continue
+		}
+
+		// recreate PVCs for each pod
+		for _, pod := range podsInNamespace.Items {
+			// check if the pod is in the `namespacesToWatch` list by doing a for loop over `d.namespacesToWatch`
+			in_watched_namespace := false
+			for _, namespace := range d.namespacesToWatch {
+				in_watched_namespace = in_watched_namespace || pod.Namespace == namespace
+			}
+			if !in_watched_namespace {
+				continue
+			}
+			// check if the pod is pending
+			if pod.Status.Phase != v1.PodPending {
+				continue
+			}
+
+			// check if the pod has a PVC claim with a storage class in `d.storageClassNames`
+			has_pvc_to_recreate := false
+			managed_storage_class := ""
+			for _, volume := range pod.Spec.Volumes {
+				if volume.PersistentVolumeClaim != nil {
+					_, err := d.client.CoreV1().PersistentVolumeClaims(pod.Namespace).Get(ctx, volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+					if err == nil {
+						continue
+					}
+
+					// check if the PVC name is in the `d.storageClassNames` list
+					for _, storageClassName := range d.storageClassNames {
+						supposedClaimName := fmt.Sprintf("%s-%s", storageClassName, pod.Name)
+						if supposedClaimName == volume.PersistentVolumeClaim.ClaimName {
+							has_pvc_to_recreate = true
+							managed_storage_class = storageClassName
+						}
+					}
+				}
+			}
+
+			if has_pvc_to_recreate {
+				klog.Infof("Pod %q in namespace %q is in pending phase and has a missing PVC from managed storage class %q, it will be deleted so that the PVC is recreated automatically", pod.Name, pod.Namespace, managed_storage_class)
+
+				err = d.client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				if err != nil && errors.IsNotFound(err) {
+					klog.Warningf("Pod %q in namespace %q no longer exists", pod.Name, pod.Namespace)
+					continue
+				} else if err != nil {
+					cleanupmetrics.PersistentVolumeClaimRecreateFailedTotal.Inc()
+					klog.Errorf("failed to delete pod %q in namespace %q: %v", pod.Name, pod.Namespace, err)
+				} else {
+					cleanupmetrics.PersistentVolumeClaimRecreateSuccessTotal.Inc()
+					klog.Infof("Pod %q in namespace %q deleted successfully, PVC will be recreated shortly after", pod.Name, pod.Namespace)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/node-cleanup/deleter/deleter_test.go
+++ b/pkg/node-cleanup/deleter/deleter_test.go
@@ -145,7 +145,7 @@ func TestDeleter(t *testing.T) {
 			pvInformer := informers.Core().V1().PersistentVolumes()
 			nodeInformer := informers.Core().V1().Nodes()
 
-			deleter := NewDeleter(client, pvInformer.Lister(), nodeInformer.Lister(), test.storageClassNames)
+			deleter := NewDeleter(client, pvInformer.Lister(), nodeInformer.Lister(), test.storageClassNames, false, nil)
 
 			// Populate the informers with initial objects so the controller can
 			// Get() and List() it.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
TL;DR: the cleanup job leads to pods pending due to non-existent PVCs that prevent the scheduler from scheduling them.

When using the LocalVolumeProviderCleanup job, deleting PVCs and PVs leads to pending pods with no PVCs attached. Thus, if the scheduler finds a valid node to schedule that workload, it will still fail to schedule to pod due to the PVC missing.

This PR addresses the issue by deleting the relevant pending pods to have the PVC recreated automatically.
I built a few safeties around the feature to ensure that it is used safely and efficiently:
* checks pods in namespaces passed as arguments
* checks pending pods only
* checks that the pod has a PVC with an eligible storage class

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
TODO: update the documentation and code examples to show how to set up the PVC recreation.

**Release note**:
```release-note

```
