### PR TITLE
fix: upgrade base image to debian-base:bookworm-v1.0.1

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 # For security, we use kubernetes community maintained debian base image.
 # https://github.com/kubernetes/release/tree/master/images/build/debian-base
-FROM registry.k8s.io/build-image/debian-base:bullseye-v1.4.3
+FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
 ARG OS=linux
 ARG ARCH=amd64
 ARG binary=./_output/${OS}/${ARCH}/local-volume-provisioner


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes critical CVES including Critical CVE-2019-8457: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/428

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #428 `, or `Fixes (https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/428)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #428 

**Special notes for your reviewer**:
Create local image using `make build-container-linux-amd64` and scan using trivy (https://github.com/aquasecurity/trivy)
```
 trivy image --severity CRITICAL registry.k8s.io/sig-storage/local-volume-provisioner:latest_linux_amd64
2024-02-12T10:15:23.866-0800	INFO	Vulnerability scanning is enabled
2024-02-12T10:15:23.866-0800	INFO	Secret scanning is enabled
2024-02-12T10:15:23.866-0800	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-02-12T10:15:23.866-0800	INFO	Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-02-12T10:15:25.582-0800	INFO	Detected OS: debian
2024-02-12T10:15:25.582-0800	INFO	Detecting Debian vulnerabilities...
2024-02-12T10:15:25.590-0800	INFO	Number of language-specific files: 1
2024-02-12T10:15:25.590-0800	INFO	Detecting gobinary vulnerabilities...

registry.k8s.io/sig-storage/local-volume-provisioner:latest_linux_amd64 (debian 12.5)

Total: 1 (CRITICAL: 1)

┌─────────┬────────────────┬──────────┬──────────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │    Status    │ Installed Version │ Fixed Version │                         Title                          │
├─────────┼────────────────┼──────────┼──────────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ zlib1g  │ CVE-2023-45853 │ CRITICAL │ will_not_fix │ 1:1.2.13.dfsg-1   │               │ zlib: integer overflow and resultant heap-based buffer │
│         │                │          │              │                   │               │ overflow in zipOpenNewFileInZip4_6                     │
│         │                │          │              │                   │               │ https://avd.aquasec.com/nvd/cve-2023-45853             │
└─────────┴────────────────┴──────────┴──────────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘
```

**Release note**:
```release-note

```
