### PR TITLE
Possibilty to add extra options to blkdiscard command

### DIFF
--- a/deployment/docker/scripts/blkdiscard.sh
+++ b/deployment/docker/scripts/blkdiscard.sh
@@ -16,7 +16,7 @@
 
 
 # Usage:
-# $ blkdiscard.sh
+# $ blkdiscard.sh <blkoptions extra options>
 
 # Import common functions.
 . $(dirname "$0")/common.sh
@@ -31,4 +31,4 @@ fi
 validateBlockDevice
 
 echo "Calling blkdiscard"
-/sbin/blkdiscard -v $LOCAL_PV_BLKDEVICE
+/sbin/blkdiscard $1 -v $LOCAL_PV_BLKDEVICE


### PR DESCRIPTION
In AWS EC2 instances `blkdiscard` is not working when cleaning a block device for Aerospike as per https://support.aerospike.com/s/article/How-to-decide-if-blkdiscard-is-preferable-to-dd

So, to do a fast clean up one might want to execute something like:
```
blkdiscard -z --length 8MiB /mnt/dev/some_device
```

By adding the possibility of sending extra options to `blkdiscard.sh`, executing the command above will be possible by configuring:
```
    local-ssd:
       hostDir: /mnt/disks
       mountDir:  /mnt/disks
       blockCleanerCommand:
         - "blkdiscard.sh"
         - -z --length 8MiB
       volumeMode: Block
```
