### PR TITLE
docs cleanup: remove references to really old k8s versions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,6 @@ on older versions, please see version links under
 ## Table of Contents
 
 - [Step 1: Bringing up a cluster with local disks](#step-1-bringing-up-a-cluster-with-local-disks)
-  * [Enabling the alpha feature gates](#enabling-the-alpha-feature-gates)
-    + [1.10-1.12](#110-112)
   * [Option 1: GCE](#option-1-gce)
   * [Option 2: GKE](#option-2-gke)
   * [Option 3: Baremetal environments](#option-3-baremetal-environments)
@@ -23,19 +21,6 @@ on older versions, please see version links under
 - [Step 4: Create local persistent volume claim](#step-4-create-local-persistent-volume-claim)
 
 ### Step 1: Bringing up a cluster with local disks
-
-#### Enabling the alpha feature gates
-
-##### 1.10-1.12
-
-If raw local block feature is needed,
-```
-$ export KUBE_FEATURE_GATES="BlockVolume=true"
-```
-
-Note: Kubernetes versions prior to 1.10 require [several additional
-feature-gates](https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v2.0.0/local-volume#enabling-the-alpha-feature-gates)
-be enabled on all Kubernetes components, because the persistent local volumes and other features were in alpha.
 
 #### Option 1: GCE
 


### PR DESCRIPTION
towards #441 

removes information on getting started page about enabling feature gates that were removed in v1.21

![CleanShot 2024-05-14 at 07 40 27@2x](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/assets/7345249/36115b87-205d-4f27-8b5b-14c2dd5dceaa)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

Does some cleanup in docs. Removes references and instructions pertaining to older Kubernetes versions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
towards #441 . I will put up some more PRs similar to this one later this week.

**Special notes for your reviewer**:


**Release note**:
```release-note

```
