### PR TITLE
feat: support applying tolerations to cleanup jobs

### DIFF
--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -23,6 +23,9 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: local-static-provisioner
 data:
+  jobTolerations: | 
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
   storageClassMap: |
     local-storage:
       hostDir: /mnt/disks
@@ -114,7 +117,7 @@ spec:
         app.kubernetes.io/name: local-static-provisioner
         app.kubernetes.io/instance: local-static-provisioner
       annotations:
-        checksum/config: f81e575a8ce66fff1873e5bae2df0f963609f540da196b9a86c3146a94d284b8
+        checksum/config: bdea962be4bc6072011b44367cc56d21c61868009d4cb63b6415c1c27695ce96
     spec:
       serviceAccountName: local-static-provisioner
       nodeSelector:

--- a/helm/provisioner/templates/configmap.yaml
+++ b/helm/provisioner/templates/configmap.yaml
@@ -27,6 +27,9 @@ data:
 {{- if .Values.useJobForCleaning }}
   useJobForCleaning: "yes"
 {{- end}}
+{{- if .Values.tolerations }}
+  jobTolerations: | {{ toYaml .Values.tolerations | nindent 4 }}
+{{- end }}
 {{- if .Values.useNodeNameOnly }}
   useNodeNameOnly: "true"
 {{- end }}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -108,6 +108,8 @@ type UserConfig struct {
 	Namespace string
 	// JobContainerImage of container to use for jobs (optional)
 	JobContainerImage string
+	// JobTolerations defines the tolerations to apply to jobs (optional)
+	JobTolerations []v1.Toleration
 	// MinResyncPeriod is minimum resync period. Resync period in reflectors
 	// will be random between MinResyncPeriod and 2*MinResyncPeriod.
 	MinResyncPeriod metav1.Duration
@@ -205,6 +207,9 @@ type ProvisionerConfiguration struct {
 	// default is false.
 	// +optional
 	UseJobForCleaning bool `json:"useJobForCleaning" yaml:"useJobForCleaning"`
+	// JobTolerations defines the tolerations to apply to jobs
+	// +optional
+	JobTolerations []v1.Toleration `json:"jobTolerations" yaml:"jobTolerations"`
 	// MinResyncPeriod is minimum resync period. Resync period in reflectors
 	// will be random between MinResyncPeriod and 2*MinResyncPeriod.
 	MinResyncPeriod metav1.Duration `json:"minResyncPeriod" yaml:"minResyncPeriod"`
@@ -397,6 +402,7 @@ func UserConfigFromProvisionerConfig(node *v1.Node, namespace, jobImage string, 
 		UseNodeNameOnly:   config.UseNodeNameOnly,
 		Namespace:         namespace,
 		JobContainerImage: jobImage,
+		JobTolerations:    config.JobTolerations,
 		LabelsForPV:       config.LabelsForPV,
 		SetPVOwnerRef:     config.SetPVOwnerRef,
 	}

--- a/pkg/deleter/deleter.go
+++ b/pkg/deleter/deleter.go
@@ -358,7 +358,7 @@ func (d *Deleter) runJob(pv *v1.PersistentVolume, volMode v1.PersistentVolumeMod
 	if d.JobContainerImage == "" {
 		return fmt.Errorf("cannot run cleanup job without specifying job image name in the environment variable")
 	}
-	job, err := NewCleanupJob(pv, volMode, d.JobContainerImage, d.Node.Name, d.Namespace, mountPath, config)
+	job, err := NewCleanupJob(pv, volMode, d.JobContainerImage, d.JobTolerations, d.Node.Name, d.Namespace, mountPath, config)
 	if err != nil {
 		return err
 	}

--- a/pkg/deleter/jobcontroller.go
+++ b/pkg/deleter/jobcontroller.go
@@ -253,7 +253,7 @@ func (c *jobController) RemoveJob(pvName string) (CleanupState, *time.Time, erro
 }
 
 // NewCleanupJob creates manifest for a cleaning job.
-func NewCleanupJob(pv *apiv1.PersistentVolume, volMode apiv1.PersistentVolumeMode, imageName string, nodeName string, namespace string, mountPath string, config common.MountConfig) (*batch_v1.Job, error) {
+func NewCleanupJob(pv *apiv1.PersistentVolume, volMode apiv1.PersistentVolumeMode, imageName string, tolerations []apiv1.Toleration, nodeName string, namespace string, mountPath string, config common.MountConfig) (*batch_v1.Job, error) {
 	priv := true
 	// Container definition
 	jobContainer := apiv1.Container{
@@ -325,6 +325,7 @@ func NewCleanupJob(pv *apiv1.PersistentVolume, volMode apiv1.PersistentVolumeMod
 		Containers:   []apiv1.Container{jobContainer},
 		Volumes:      volumes,
 		NodeSelector: map[string]string{common.NodeNameLabel: nodeName},
+		Tolerations:  tolerations,
 	}
 	podTemplate.ObjectMeta = meta_v1.ObjectMeta{
 		Name:        generateCleaningJobName(pv.Name),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

At the moment, if the DaemonSet is deployed with tolerations, and `useJobForCleaning: true`, those tolerations do not get transferred to deployed Jobs. If, for example, the DaemonSet tolerates running on control plane nodes, the cleanup jobs it deploys targeting those nodes will never get scheduled due to lack of toleration. By adding a tolerations field to the config, the Helm chart can automatically populate it based on `.Values.tolerations`. Now all deployed jobs should inherit the same tolerations as the parent DaemonSet.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #253

<!--
**Special notes for your reviewer**:


**Release note**:
```release-note

```
-->