### PR TITLE
feat: add accessMode parameter in storageClassMap

### DIFF
--- a/deployment/kubernetes/example/default_example_provisioner_generated.yaml
+++ b/deployment/kubernetes/example/default_example_provisioner_generated.yaml
@@ -15,6 +15,7 @@ data:
          - "/scripts/shred.sh"
          - "2"
        volumeMode: Filesystem
+       accessMode: ReadWriteOnce
        fsType: ext4
        namePattern: "*"
 ---

--- a/docs/provisioner.md
+++ b/docs/provisioner.md
@@ -128,6 +128,8 @@ data:
   #       # intended to use as a formatted filesystem volume or to remain in block
   #       # state. Value of Filesystem is implied when omitted.
   #       volumeMode: Filesystem
+  #       # Access mode of the volume. default to ReadWriteOnce if not specified.
+  #       accessMode: ReadWriteOnce
   #       # The filesystem to format before mounting on the node. This applies
   #       # only when the volume source is a device and mode is Filesystem.
   #       # The default value is to auto-select a filesystem in Kubernetes if unspecified.

--- a/helm/examples/baremetal-default-storage.yaml
+++ b/helm/examples/baremetal-default-storage.yaml
@@ -2,6 +2,7 @@ classes:
 - name: local-storage
   hostDir: /mnt/disks
   volumeMode: Filesystem
+  accessMode: ReadWriteOnce
   storageClass: 
     # create and set storage class as default
     isDefaultClass: true

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -62,6 +62,8 @@ classes:
     # The volume mode of created PersistentVolume object. Default to Filesystem
     # if not specified.
     volumeMode: Filesystem
+    # Access mode of the volume. default to ReadWriteOnce if not specified.
+    accessMode: ReadWriteOnce
     # Filesystem type to mount.
     # It applies only when the source path is a block device,
     # and desire volume mode is Filesystem.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -132,6 +132,9 @@ type MountConfig struct {
 	// The volume mode of created PersistentVolume object,
 	// default to Filesystem if not specified.
 	VolumeMode string `json:"volumeMode" yaml:"volumeMode"`
+	// The access mode of created PersistentVolume object
+	// default to ReadWriteOnce if not specified.
+	AccessMode string `json:"accessMode" yaml:"accessMode"`
 	// Filesystem type to mount.
 	// It applies only when the source path is a block device,
 	// and desire volume mode is Filesystem.
@@ -180,6 +183,7 @@ type LocalPVConfig struct {
 	AffinityAnn     string
 	NodeAffinity    *v1.VolumeNodeAffinity
 	VolumeMode      v1.PersistentVolumeMode
+	AccessMode      v1.PersistentVolumeAccessMode
 	MountOptions    []string
 	FsType          *string
 	Labels          map[string]string
@@ -248,12 +252,16 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 				},
 			},
 			AccessModes: []v1.PersistentVolumeAccessMode{
-				v1.ReadWriteOnce,
+				config.AccessMode,
 			},
 			StorageClassName: config.StorageClass,
 			VolumeMode:       &config.VolumeMode,
 			MountOptions:     config.MountOptions,
 		},
+	}
+
+	if config.AccessMode == "" {
+		pv.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 	}
 
 	if config.UseAlphaAPI {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: add accessMode parameter in storageClassMap

 - verified it works on local env
```yaml
# k get pv local-pv-48445918 -o yaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: local-volume-provisioner-aks-azure-40425242-vmss000000-db96b70f-a23b-4920-86a4-b098adfc6b3c
  creationTimestamp: "2025-01-01T09:43:30Z"
  finalizers:
  - kubernetes.io/pv-protection
  name: local-pv-48445918
  resourceVersion: "100759036"
  uid: 8688b7b4-093c-4f1f-b23f-b553a93e9d18
spec:
  accessModes:
  - ReadWriteOncePod
  capacity:
    storage: 15Gi
  local:
    fsType: ext4
    path: /dev/disk/cloud/azure_resource-part1
  nodeAffinity:
    required:
      nodeSelectorTerms:
      - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - aks-azure-40425242-vmss000000
  persistentVolumeReclaimPolicy: Delete
  storageClassName: local-disk
  volumeMode: Filesystem
status:
  lastPhaseTransitionTime: "2025-01-01T09:43:30Z"
  phase: Available
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #467

**Special notes for your reviewer**:


**Release note**:
```release-note
feat: add accessMode parameter in storageClassMap
```
