### PR TITLE
chore: fix image build failure

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ timeout: 5400s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-- name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36
+- name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20250116-2a05ea7e3d
   entrypoint: hack/release.sh
   env:
   - REGISTRY=gcr.io/${_STAGING_PROJECT}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
chore: fix image build failure

https://github.com/kubernetes/test-infra/tree/master/images/gcb-docker-gcloud
https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud?invt=AbtI2A

```
Setting /usr/bin/qemu-hexagon-static as binfmt interpreter for hexagon
# Register gcloud as a Docker credential helper.
# Required for "docker buildx build --push".
gcloud auth configure-docker --quiet
Adding credentials for all GCR repositories.
WARNING: A long list of credential helpers may cause delays running 'docker build'. We recommend passing the registry name to configure only the registry you are using.
Docker configuration file updated.
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -mod vendor -o _output/linux/amd64/local-volume-provisioner ./cmd/local-volume-provisioner
go: go.mod requires go >= 1.23.0 (running go 1.22.5; GOTOOLCHAIN=local)
make: *** [Makefile:77: build-and-push-container-linux-amd64] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36" failed: step exited with non-zero status: 2
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note

```
