### PR TITLE
chore: bump to go1.23.8 to fix image build failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module sigs.k8s.io/sig-storage-local-static-provisioner
 
-go 1.24
+go 1.23.8
 
 require (
 	github.com/golang/glog v1.1.2
+	github.com/google/go-cmp v0.6.0
 	github.com/kubernetes-csi/csi-proxy/client v1.0.2
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
@@ -55,7 +56,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/cel-go v0.17.7 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
chore: bump to go1.23.8 to fix image build failure

and `gcb-docker-gcloud` image does not support go1.24:
https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud?invt=AbuyYQ

```
Docker configuration file updated.
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -mod vendor -o _output/linux/amd64/local-volume-provisioner ./cmd/local-volume-provisioner
go: go.mod requires go >= 1.24 (running go 1.23.4; GOTOOLCHAIN=local)
make: *** [Makefile:77: build-and-push-container-linux-amd64] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d" failed: step exited with non-zero status: 2
--------------------------------------------------------------------------------
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note
none
```
