### PR TITLE
feat: allow configuring the updateStrategy for the DaemonSet

### DIFF
--- a/helm/generated_examples/additional-volumes.yaml
+++ b/helm/generated_examples/additional-volumes.yaml
@@ -96,6 +96,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-affinity.yaml
+++ b/helm/generated_examples/baremetal-affinity.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-cleanbyjobs.yaml
+++ b/helm/generated_examples/baremetal-cleanbyjobs.yaml
@@ -147,6 +147,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-default-storage.yaml
+++ b/helm/generated_examples/baremetal-default-storage.yaml
@@ -107,6 +107,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-nodeselector.yaml
+++ b/helm/generated_examples/baremetal-nodeselector.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-priority-critical.yaml
+++ b/helm/generated_examples/baremetal-priority-critical.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-priority-noncritical.yaml
+++ b/helm/generated_examples/baremetal-priority-noncritical.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-prometheus.yaml
+++ b/helm/generated_examples/baremetal-prometheus.yaml
@@ -129,6 +129,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-provisioner.yaml
+++ b/helm/generated_examples/baremetal-provisioner.yaml
@@ -107,6 +107,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-resyncperiod.yaml
+++ b/helm/generated_examples/baremetal-resyncperiod.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -111,6 +111,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-with-resource-limits.yaml
+++ b/helm/generated_examples/baremetal-with-resource-limits.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal-without-rbac.yaml
+++ b/helm/generated_examples/baremetal-without-rbac.yaml
@@ -61,6 +61,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/baremetal.yaml
+++ b/helm/generated_examples/baremetal.yaml
@@ -108,6 +108,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/development-gce.yaml
+++ b/helm/generated_examples/development-gce.yaml
@@ -105,6 +105,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/development-gke.yaml
+++ b/helm/generated_examples/development-gke.yaml
@@ -105,6 +105,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/eks-nvme-ssd.yaml
+++ b/helm/generated_examples/eks-nvme-ssd.yaml
@@ -104,6 +104,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/gce-retain.yaml
+++ b/helm/generated_examples/gce-retain.yaml
@@ -122,6 +122,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/gce.yaml
+++ b/helm/generated_examples/gce.yaml
@@ -122,6 +122,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
+++ b/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
@@ -105,6 +105,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/generated_examples/gke.yaml
+++ b/helm/generated_examples/gke.yaml
@@ -105,6 +105,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: local-static-provisioner
       app.kubernetes.io/instance: local-static-provisioner
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -14,6 +14,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "provisioner.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
   template:
     metadata:
       labels:

--- a/helm/provisioner/templates/daemonset_windows.yaml
+++ b/helm/provisioner/templates/daemonset_windows.yaml
@@ -15,6 +15,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "provisioner.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
   template:
     metadata:
       labels:

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -158,6 +158,12 @@ hostPID: false
 # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 initContainers: []
 
+# Update strategy for the DaemonSet.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
 #
 # Configure Prometheus monitoring
 #


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This allows users of the Helm chart to configure the updateStrategy for the installed DaemonSet.

Clusters with a lot of nodes frequently need to increase the `maxUnavailable` for the DaemonSet in order for updates to complete within the deployment system's timeout. Since update concurrency doesn't need to be severely limited for workload availability, this is safe.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```release-note
feat: allow configuring the updateStrategy for the DaemonSet
```
