### PR TITLE
Support for removing start up taint

### DIFF
--- a/helm/generated_examples/additional-volumes.yaml
+++ b/helm/generated_examples/additional-volumes.yaml
@@ -59,7 +59,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-affinity.yaml
+++ b/helm/generated_examples/baremetal-affinity.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-cleanbyjobs.yaml
+++ b/helm/generated_examples/baremetal-cleanbyjobs.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-default-storage.yaml
+++ b/helm/generated_examples/baremetal-default-storage.yaml
@@ -70,7 +70,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-nodeselector.yaml
+++ b/helm/generated_examples/baremetal-nodeselector.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-priority-critical.yaml
+++ b/helm/generated_examples/baremetal-priority-critical.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-priority-noncritical.yaml
+++ b/helm/generated_examples/baremetal-priority-noncritical.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-prometheus.yaml
+++ b/helm/generated_examples/baremetal-prometheus.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-provisioner.yaml
+++ b/helm/generated_examples/baremetal-provisioner.yaml
@@ -70,7 +70,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-resyncperiod.yaml
+++ b/helm/generated_examples/baremetal-resyncperiod.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -74,7 +74,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -128,7 +128,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
       containers:

--- a/helm/generated_examples/baremetal-with-resource-limits.yaml
+++ b/helm/generated_examples/baremetal-with-resource-limits.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/baremetal.yaml
+++ b/helm/generated_examples/baremetal.yaml
@@ -71,7 +71,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/development-gce.yaml
+++ b/helm/generated_examples/development-gce.yaml
@@ -68,7 +68,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/development-gke.yaml
+++ b/helm/generated_examples/development-gke.yaml
@@ -68,7 +68,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/eks-nvme-ssd.yaml
+++ b/helm/generated_examples/eks-nvme-ssd.yaml
@@ -67,7 +67,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/gce-retain.yaml
+++ b/helm/generated_examples/gce-retain.yaml
@@ -85,7 +85,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/gce.yaml
+++ b/helm/generated_examples/gce.yaml
@@ -85,7 +85,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
+++ b/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
@@ -68,7 +68,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/generated_examples/gke.yaml
+++ b/helm/generated_examples/gke.yaml
@@ -68,7 +68,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 ---
 # Source: local-static-provisioner/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/provisioner/templates/configmap.yaml
+++ b/helm/provisioner/templates/configmap.yaml
@@ -24,6 +24,10 @@ data:
 {{- if .Values.setPVOwnerRef }}
   setPVOwnerRef: "true"
 {{- end }}
+{{- if .Values.removeNodeNotReadyTaint }}
+  removeNodeNotReadyTaint: {{ .Values.removeNodeNotReadyTaint | quote }}
+  provisionerNotReadyNodeTaintKey: {{ .Values.provisionerNotReadyNodeTaintKey | quote }}
+{{- end }}
 {{- if .Values.useJobForCleaning }}
   useJobForCleaning: "yes"
 {{- end }}

--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -44,9 +44,15 @@ spec:
 {{- if .Values.nodeSelector }}
         {{ toYaml .Values.nodeSelector | nindent 8 }}
 {{- end }}
-{{- if .Values.tolerations }}
+{{- if or (.Values.tolerations) (.Values.removeNodeNotReadyTaint) }}
       tolerations:
-        {{ toYaml .Values.tolerations | nindent 8 }}
+{{- if .Values.tolerations}}
+        {{- toYaml .Values.tolerations | nindent 8 }}
+{{- end }}
+{{- if .Values.removeNodeNotReadyTaint }}
+        - key: {{ .Values.provisionerNotReadyNodeTaintKey}}
+          operator: Exists
+{{- end }}
 {{- end }}
 {{- if .Values.affinity }}
       affinity:

--- a/helm/provisioner/templates/rbac.yaml
+++ b/helm/provisioner/templates/rbac.yaml
@@ -23,7 +23,7 @@ rules:
   verbs: ["create", "update", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get"]
+  verbs: ["get", "update"]
 {{- if .Values.rbac.extraRules }}
 {{ toYaml .Values.rbac.extraRules }}
 {{- end}}

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -133,6 +133,17 @@ nodeSelectorWindows: {}
 # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 #
+# If configured, removeNodeNotReadyTaint will add provisionerNotReadyNodeTaintKey as the toleration key
+# to the DaemonSet PodSpec.
+#
+# removeNodeNotReadyTaint controls whether the provisioner should remove the provisionerNotReadyNodeTaintKey
+# once it becomes ready.
+removeNodeNotReadyTaint: false
+#
+# The key of the startup taint that provisioner will remove once it becomes ready.
+# Ref: https://karpenter.sh/docs/concepts/nodepools/#cilium-startup-taint
+provisionerNotReadyNodeTaintKey: "sig-storage-local-static-provisioner/agent-not-ready"
+#
 # If configured, affinity will add a affinity filed to the DeamonSet PodSpec.
 # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -119,6 +119,11 @@ type UserConfig struct {
 	LabelsForPV map[string]string
 	// SetPVOwnerRef indicates if PVs should be dependents of the owner Node
 	SetPVOwnerRef bool
+	// RemoveNodeNotReadyTaint indicates if the provisioner should remove the taint with provisionerNotReadyNodeTaintKey
+	// once it becomes ready.
+	RemoveNodeNotReadyTaint bool
+	// ProvisionerNotReadyNodeTaintKey is the key of the startup taint that provisioner will remove once it becomes ready.
+	ProvisionerNotReadyNodeTaintKey string
 }
 
 // MountConfig stores a configuration for discoverying a specific storageclass
@@ -228,6 +233,13 @@ type ProvisionerConfiguration struct {
 	LabelsForPV map[string]string `json:"labelsForPV" yaml:"labelsForPV"`
 	// SetPVOwnerRef indicates if PVs should be dependents of the owner Node, default to false
 	SetPVOwnerRef bool `json:"setPVOwnerRef" yaml:"setPVOwnerRef"`
+	// RemoveNodeNotReadyTaint controls whether the provisioner should remove the taint with provisionerNotReadyNodeTaintKey
+	// once it becomes ready.
+	// +optional
+	RemoveNodeNotReadyTaint bool `json:"removeNodeNotReadyTaint" yaml:"removeNodeNotReadyTaint"`
+	// ProvisionerNotReadyNodeTaintKey is the key of the startup taint that provisioner will remove once it becomes ready.
+	// +optional
+	ProvisionerNotReadyNodeTaintKey string `json:"provisionerNotReadyNodeTaintKey" yaml:"provisionerNotReadyNodeTaintKey"`
 }
 
 // CreateLocalPVSpec returns a PV spec that can be used for PV creation
@@ -403,18 +415,20 @@ func insertSpaces(original string) string {
 // UserConfigFromProvisionerConfig creates a UserConfig from the provided ProvisionerConfiguration struct
 func UserConfigFromProvisionerConfig(node *v1.Node, namespace, jobImage string, config ProvisionerConfiguration) *UserConfig {
 	return &UserConfig{
-		Node:              node,
-		DiscoveryMap:      config.StorageClassConfig,
-		NodeLabelsForPV:   config.NodeLabelsForPV,
-		UseAlphaAPI:       config.UseAlphaAPI,
-		UseJobForCleaning: config.UseJobForCleaning,
-		MinResyncPeriod:   config.MinResyncPeriod,
-		UseNodeNameOnly:   config.UseNodeNameOnly,
-		Namespace:         namespace,
-		JobContainerImage: jobImage,
-		JobTolerations:    config.JobTolerations,
-		LabelsForPV:       config.LabelsForPV,
-		SetPVOwnerRef:     config.SetPVOwnerRef,
+		Node:                            node,
+		DiscoveryMap:                    config.StorageClassConfig,
+		NodeLabelsForPV:                 config.NodeLabelsForPV,
+		UseAlphaAPI:                     config.UseAlphaAPI,
+		UseJobForCleaning:               config.UseJobForCleaning,
+		MinResyncPeriod:                 config.MinResyncPeriod,
+		UseNodeNameOnly:                 config.UseNodeNameOnly,
+		Namespace:                       namespace,
+		JobContainerImage:               jobImage,
+		JobTolerations:                  config.JobTolerations,
+		LabelsForPV:                     config.LabelsForPV,
+		SetPVOwnerRef:                   config.SetPVOwnerRef,
+		RemoveNodeNotReadyTaint:         config.RemoveNodeNotReadyTaint,
+		ProvisionerNotReadyNodeTaintKey: config.ProvisionerNotReadyNodeTaintKey,
 	}
 }
 

--- a/pkg/node-taint/node_taint.go
+++ b/pkg/node-taint/node_taint.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetaint
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
+)
+
+const (
+	maxRemoveTaintRetries  = 3
+	removeTaintRetryPeriod = 5 * time.Second
+)
+
+// Remover is responsible for removing the node taint that indidcates the provisioner is not ready yet.
+type Remover struct {
+	RuntimeConfig *common.RuntimeConfig
+	taintRemoved  bool
+}
+
+// NewRemover creates an instances of RemoveNodeNotReadyTaint.
+func NewRemover(runtimeConfig *common.RuntimeConfig) *Remover {
+	return &Remover{
+		RuntimeConfig: runtimeConfig,
+		taintRemoved:  false,
+	}
+}
+
+// RemoveNodeTaint searches for the provisionerNotReadyNodeTaintKey and removes it from the node.
+// it only removes the taint once.
+func (n *Remover) RemoveNodeTaint() error {
+	userConfig := n.RuntimeConfig.UserConfig
+	if !userConfig.RemoveNodeNotReadyTaint || n.taintRemoved {
+		return nil
+	}
+
+	client := n.RuntimeConfig.Client.CoreV1()
+	node := util.GetNode(client, n.RuntimeConfig.Node.Name)
+
+	var taintExists bool
+	currTaints := []corev1.Taint{}
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == userConfig.ProvisionerNotReadyNodeTaintKey {
+			taintExists = true
+		} else {
+			currTaints = append(currTaints, taint)
+		}
+	}
+
+	if !taintExists {
+		klog.Infof("ProvisionerNotReadyNodeTaintKey %s was not found on node %s", userConfig.ProvisionerNotReadyNodeTaintKey, node.Name)
+		return nil
+	}
+
+	node.Spec.Taints = currTaints
+	_, err := client.Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("failed to remove node taint %s from node %s: %v", userConfig.ProvisionerNotReadyNodeTaintKey, node.Name, err)
+		return err
+	}
+
+	n.taintRemoved = true
+	klog.Infof("removed node taint %s from node %s", userConfig.ProvisionerNotReadyNodeTaintKey, node.Name)
+	return nil
+}
+
+// ShouldRemoveTaint returns true if the taint is not removed already and the user config is set to remove the taint.
+func (n *Remover) ShouldRemoveTaint() bool {
+	return !n.taintRemoved && n.RuntimeConfig.UserConfig.RemoveNodeNotReadyTaint
+}
+
+// RemoveTaintWithBackoff removes the taint if the taint is not removed already, it performs linear randomized backoff upon failure.
+func (n *Remover) RemoveTaintWithBackoff() {
+	retries := 0
+	retryPeriod := time.Duration(0 * time.Second)
+	for n.ShouldRemoveTaint() && retries < maxRemoveTaintRetries {
+		err := n.RemoveNodeTaint()
+		if err == nil {
+			return
+		}
+		retries++
+		// randomized retry period
+		retryPeriodInSeconds := int(removeTaintRetryPeriod / time.Second)
+		randomSeconds := rand.Intn(retryPeriodInSeconds)
+		retryPeriod += time.Duration(randomSeconds) * time.Second
+		time.Sleep(retryPeriod)
+	}
+	if retries == maxRemoveTaintRetries {
+		klog.Errorf("failed to remove node taint %s from node %s after %d retries", n.RuntimeConfig.UserConfig.ProvisionerNotReadyNodeTaintKey, n.RuntimeConfig.Node.Name, maxRemoveTaintRetries)
+	}
+}

--- a/pkg/node-taint/node_taint_test.go
+++ b/pkg/node-taint/node_taint_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetaint
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+)
+
+type testCase struct {
+	name                 string
+	node                 *corev1.Node
+	userConfig           *common.UserConfig
+	expectedTaints       []corev1.Taint
+	expectedTaintRemoved bool
+}
+
+func TestRemoveNodeTaint(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "should remove taint when it exists",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "test-taint-key", Value: "test-value", Effect: corev1.TaintEffectNoSchedule},
+						{Key: "other-taint", Value: "other-value", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+			userConfig: &common.UserConfig{
+				RemoveNodeNotReadyTaint:         true,
+				ProvisionerNotReadyNodeTaintKey: "test-taint-key",
+			},
+			expectedTaints: []corev1.Taint{
+				{Key: "other-taint", Value: "other-value", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expectedTaintRemoved: true,
+		},
+		{
+			name: "should not remove taint when RemoveNodeNotReadyTaint is false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "test-taint-key", Value: "test-value", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+			userConfig: &common.UserConfig{
+				RemoveNodeNotReadyTaint:         false,
+				ProvisionerNotReadyNodeTaintKey: "test-taint-key",
+			},
+			expectedTaints: []corev1.Taint{
+				{Key: "test-taint-key", Value: "test-value", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expectedTaintRemoved: false,
+		},
+		{
+			name: "should not remove taint when it doesn't exist",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "other-taint", Value: "other-value", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+			userConfig: &common.UserConfig{
+				RemoveNodeNotReadyTaint:         true,
+				ProvisionerNotReadyNodeTaintKey: "test-taint-key",
+			},
+			expectedTaints: []corev1.Taint{
+				{Key: "other-taint", Value: "other-value", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expectedTaintRemoved: false,
+		},
+		{
+			name: "should not remove taint when already removed",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{Key: "test-taint-key", Value: "test-value", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+			userConfig: &common.UserConfig{
+				RemoveNodeNotReadyTaint:         true,
+				ProvisionerNotReadyNodeTaintKey: "test-taint-key",
+			},
+			expectedTaints: []corev1.Taint{
+				{Key: "test-taint-key", Value: "test-value", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expectedTaintRemoved: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tc.node)
+
+			runtimeConfig := &common.RuntimeConfig{
+				UserConfig: tc.userConfig,
+				Client:     fakeClient,
+			}
+			runtimeConfig.UserConfig.Node = tc.node
+
+			// For the "already removed" test case, mark taint as already removed
+			remover := NewRemover(runtimeConfig)
+			if tc.name == "should not remove taint when already removed" {
+				remover.taintRemoved = true
+			}
+
+			err := remover.RemoveNodeTaint()
+			if err != nil {
+				t.Errorf("failed to remove node taint: %v", err)
+			}
+
+			updatedNode, err := fakeClient.CoreV1().Nodes().Get(context.Background(), tc.node.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get updated node: %v", err)
+			}
+			if len(tc.expectedTaints) != len(updatedNode.Spec.Taints) {
+				t.Errorf("expected %d taints, got %d", len(tc.expectedTaints), len(updatedNode.Spec.Taints))
+			}
+
+			// Verify taintRemoved flag
+			if remover.taintRemoved != tc.expectedTaintRemoved {
+				t.Errorf("expected taintRemoved to be %v, got %v", tc.expectedTaintRemoved, remover.taintRemoved)
+			}
+		})
+	}
+}

--- a/pkg/util/node_util.go
+++ b/pkg/util/node_util.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const maxGetNodesRetries = 3
+
+// GetNode returns the node with the given name.
+func GetNode(client corev1.CoreV1Interface, name string) *v1.Node {
+	var retries int
+
+	for {
+		node, err := client.Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return node
+		}
+
+		retries++
+		klog.Infof("Could not get node information (remaining retries: %d): %v", maxGetNodesRetries-retries, err)
+
+		if retries >= maxGetNodesRetries {
+			klog.Fatalf("Could not get node information: %v", err)
+		}
+		time.Sleep(time.Second)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds support for removing [node startup taints](https://github.com/aws/karpenter-provider-aws/issues/628) with an approach similar to [Cilium](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/) and [aws ebs csi driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1232). 

When nodes start up or get provisioned, there is certain delay till the local-static-provisioner becomes ready. This could cause race condition with the scheduler, because other workload pods with a local PVC request might get scheduled on the node and stuck waiting for their volumes be provisioned. 

This PR assumes that the node provisioner already adds some start up taints, and when the local-static-provisioner becomes ready, removes them. 

We do it only once at the node starts up.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:


**Release note**:
```release-note

```
