### PR TITLE
fix: Add permissions chart-release workflow

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -27,7 +29,6 @@ jobs:
       - name: Set-up Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
 
       - name: Run chart-releaser


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the chart release action so that new versions can be published and used.

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes token permissions to the helm chart release action so that charts can be released without authentication errors.

Closes #496 

Last failed run: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/actions/runs/14637113016/job/41073324459

**Special notes for your reviewer**:


**Release note**:
```release-note
none: re-run action for 2.8.8 release
```
