### PR TITLE
fix: Update example to use the correct tag on `startup-script`

### DIFF
--- a/examples/gke-daemonset-raid-disks.yaml
+++ b/examples/gke-daemonset-raid-disks.yaml
@@ -26,7 +26,7 @@ spec:
       hostPID: true
       containers:
       - name: startup-script
-        image: registry.k8s.io/startup-script:v1
+        image: registry.k8s.io/startup-script:v2
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature
> /kind flake

/kind documentation

**What this PR does / why we need it**:

Update documentation/example to use the correct tag for the `startup-script`

Before:

```
$ kubectl get pods
NAME                   READY   STATUS         RESTARTS   AGE
gke-raid-disks-gj76p   0/1     ErrImagePull   0          10s
gke-raid-disks-kv6dl   0/1     ErrImagePull   0          10s
gke-raid-disks-mx7mr   0/1     ErrImagePull   0          10s
```

After:
```
$ kubectl logs gke-raid-disks-bwfwd       
Setting RAID array with Local SSDs on device /dev/md/*
mdadm: Defaulting to version 1.2 metadata
mdadm: array /dev/md/0 started.
tune2fs: Bad magic number in super-block while trying to open /dev/md/0
tune2fs 1.47.0 (5-Feb-2023)
Formatting '/dev/md/0'
mke2fs 1.47.0 (5-Feb-2023)
Discarding device blocks: done                            
Creating filesystem with 98270976 4k blocks and 24567808 inodes
Filesystem UUID: 24c52a5b-18d2-425d-a0e9-0f17ef9a1f03
Superblock backups stored on blocks: 
        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208, 
        4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (262144 blocks): done
Writing superblocks and filesystem accounting information: done     

Mounting '/dev/md/0' at '/mnt/disks/raid/0'
!!! startup-script succeeded!
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #512 

**Special notes for your reviewer**:


**Release note**:
```release-note

```
