### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/cmd/local-volume-provisioner/main.go
+++ b/cmd/local-volume-provisioner/main.go
@@ -54,6 +54,8 @@ func main() {
 	flag.DurationVar(&configSyncPeriod, "config-sync-period", 5*time.Second, "the period to check if there has been any config changes")
 	flag.Parse()
 	flag.Set("logtostderr", "true")
+	flag.Set("legacy_stderr_threshold_behavior", "false")
+	flag.Set("stderrthreshold", "INFO")
 
 	provisionerConfig := common.ProvisionerConfiguration{
 		StorageClassConfig: make(map[string]common.MountConfig),

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	k8s.io/apiserver v0.32.10
 	k8s.io/client-go v0.32.10
 	k8s.io/component-base v0.32.10
-	k8s.io/klog/v2 v2.130.1
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubernetes v1.32.10
 	k8s.io/pod-security-admission v0.0.0
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,9 @@ k8s.io/gengo/v2 v2.0.0-20240826214909-a7b603a56eb7/go.mod h1:EJykeLsmFC60UQbYJez
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.3.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
-k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kms v0.32.10 h1:TOKCISpp+fmWZyHyfNLExW5oeYgFdqHc1j7Ibux+XdQ=
 k8s.io/kms v0.32.10/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJJ4JRdzg3+O6e8I+e+8T5Y=


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When `logtostderr` is set to `true`, klog's `stderrthreshold` flag is ignored due to a legacy default behavior in klog v2. This means all log levels (including INFO and DEBUG) are written to stderr, regardless of the `stderrthreshold` setting already configured in `main.go`.

This PR:
1. Bumps `k8s.io/klog/v2` from v2.130.1 to v2.140.0 to get the fix from [klog PR #432](https://github.com/kubernetes/klog/pull/432)
2. Sets `legacy_stderr_threshold_behavior` to `false` to opt into the corrected behavior where `stderrthreshold` is respected even when `logtostderr=true`

## Which issue(s) this PR fixes

Fixes a logging behavior issue where the existing `stderrthreshold=WARNING` setting was silently ignored.

## Special notes for your reviewer

The `legacy_stderr_threshold_behavior` flag was introduced in klog v2.140.0 ([klog PR #432](https://github.com/kubernetes/klog/pull/432)). Setting it to `false` opts into the corrected behavior. The klog bump is a minor version upgrade with no breaking changes.

> This contribution is AI-assisted.