### PR TITLE
chore: bump Go version to 1.25.10 in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       
       - name: Build an image from Dockerfile
         run: |


### PR DESCRIPTION
## What this PR does

Bumps the Go version from 1.25.9 to 1.25.10 in the trivy security scan workflow.

/kind cleanup