### PR TITLE
feat(helm): add support for configurable health probes on the provisioner container

### DIFF
--- a/helm/generated_examples/additional-volumes.yaml
+++ b/helm/generated_examples/additional-volumes.yaml
@@ -142,6 +142,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-affinity.yaml
+++ b/helm/generated_examples/baremetal-affinity.yaml
@@ -150,6 +150,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-cleanbyjobs.yaml
+++ b/helm/generated_examples/baremetal-cleanbyjobs.yaml
@@ -179,6 +179,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-default-storage.yaml
+++ b/helm/generated_examples/baremetal-default-storage.yaml
@@ -140,6 +140,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-nodeselector.yaml
+++ b/helm/generated_examples/baremetal-nodeselector.yaml
@@ -142,6 +142,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-priority-critical.yaml
+++ b/helm/generated_examples/baremetal-priority-critical.yaml
@@ -141,6 +141,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-priority-noncritical.yaml
+++ b/helm/generated_examples/baremetal-priority-noncritical.yaml
@@ -141,6 +141,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-prometheus.yaml
+++ b/helm/generated_examples/baremetal-prometheus.yaml
@@ -161,6 +161,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-provisioner.yaml
+++ b/helm/generated_examples/baremetal-provisioner.yaml
@@ -139,6 +139,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-resyncperiod.yaml
+++ b/helm/generated_examples/baremetal-resyncperiod.yaml
@@ -140,6 +140,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-tolerations.yaml
+++ b/helm/generated_examples/baremetal-tolerations.yaml
@@ -146,6 +146,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-with-resource-limits.yaml
+++ b/helm/generated_examples/baremetal-with-resource-limits.yaml
@@ -148,6 +148,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal-without-rbac.yaml
+++ b/helm/generated_examples/baremetal-without-rbac.yaml
@@ -93,6 +93,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/baremetal.yaml
+++ b/helm/generated_examples/baremetal.yaml
@@ -140,6 +140,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/development-gce.yaml
+++ b/helm/generated_examples/development-gce.yaml
@@ -138,6 +138,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: gcr.io/k8s-staging-sig-storage/local-volume-provisioner:canary
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/development-gke.yaml
+++ b/helm/generated_examples/development-gke.yaml
@@ -138,6 +138,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: gcr.io/k8s-staging-sig-storage/local-volume-provisioner:canary
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/eks-nvme-ssd.yaml
+++ b/helm/generated_examples/eks-nvme-ssd.yaml
@@ -136,6 +136,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce-retain.yaml
+++ b/helm/generated_examples/gce-retain.yaml
@@ -154,6 +154,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gce.yaml
+++ b/helm/generated_examples/gce.yaml
@@ -154,6 +154,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
+++ b/helm/generated_examples/gke-nvme-ssd-block-raid.yaml
@@ -137,6 +137,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/generated_examples/gke.yaml
+++ b/helm/generated_examples/gke.yaml
@@ -137,6 +137,13 @@ spec:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
             value: registry.k8s.io/sig-storage/local-volume-provisioner:v2.8.0
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            tcpSocket:
+              port: metrics
+            timeoutSeconds: 5
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -89,6 +89,18 @@ spec:
           - name: KUBECONFIG
             value: {{.Values.kubeConfigEnv}}
           {{- end }}
+{{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/provisioner/templates/daemonset_windows.yaml
+++ b/helm/provisioner/templates/daemonset_windows.yaml
@@ -84,6 +84,18 @@ spec:
           - name: KUBECONFIG
             value: {{.Values.kubeConfigEnv}}
           {{- end }}
+{{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+{{- end }}
           ports:
           - name: metrics
             containerPort: 8080

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -165,6 +165,23 @@ privileged: true
 # Host PID set in the linux daemonset container spec. When set to true allows a pod to have access to the host process ID namespace
 hostPID: false
 
+# Liveness probe for the provisioner container.
+# Uses tcpSocket to verify the process is alive without coupling to readiness state.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  tcpSocket:
+    port: metrics
+  initialDelaySeconds: 10
+  periodSeconds: 60
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# Readiness probe for the provisioner container.
+readinessProbe: {}
+
+# Startup probe for the provisioner container.
+startupProbe: {}
+
 # Any init containers can be configured here.
 # Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 initContainers: []


### PR DESCRIPTION
## What this PR does

Add optional `livenessProbe`, `readinessProbe`, and `startupProbe` configuration to the Helm chart values. These are rendered conditionally in both the Linux and Windows DaemonSet templates.

A **default livenessProbe** is provided out of the box using `tcpSocket`:

```yaml
livenessProbe:
  tcpSocket:
    port: metrics
  initialDelaySeconds: 10
  periodSeconds: 60
  timeoutSeconds: 5
  failureThreshold: 3
```

This uses a simple TCP port check rather than the `/ready` endpoint, because `/ready` reflects discovery state and could cause unnecessary pod restarts on transient discovery errors.

`readinessProbe` and `startupProbe` default to empty (`{}`) and are not rendered unless the user configures them.

## Why

The provisioner DaemonSet container does not define any health probes, and there is no way to configure them via Helm values. In clusters that enforce probe requirements through admission policies (e.g. Kyverno's `check-probes`), the provisioner pods are rejected because they lack at least one probe.

## Usage

Users can override the default or add additional probes:

```yaml
# values.yaml - custom configuration
livenessProbe:
  tcpSocket:
    port: metrics
  initialDelaySeconds: 30
  periodSeconds: 120

readinessProbe:
  httpGet:
    path: /ready
    port: metrics
  initialDelaySeconds: 5
  periodSeconds: 10

startupProbe: {}
```

## Changes

- `helm/provisioner/values.yaml`: Add `livenessProbe` (with tcpSocket default), `readinessProbe`, `startupProbe` fields
- `helm/provisioner/templates/daemonset_linux.yaml`: Conditionally render probes
- `helm/provisioner/templates/daemonset_windows.yaml`: Conditionally render probes
- `helm/generated_examples/*`: Regenerated to reflect the new default livenessProbe

Related: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/556