### PR TITLE
feat(helm): allow configuring the full container securityContext via Helm values

### DIFF
--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -69,7 +69,11 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- end }}
           securityContext:
+{{- if .Values.securityContext }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
+{{- else }}
             privileged: {{ .Values.privileged }}
+{{- end }}
 {{- if .Values.resources }}
           resources:
             {{ toYaml .Values.resources | nindent 12 }}

--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -70,6 +70,9 @@ spec:
           {{- end }}
           securityContext:
 {{- if .Values.securityContext }}
+{{- if not (hasKey .Values.securityContext "privileged") }}
+            privileged: {{ .Values.privileged }}
+{{- end }}
             {{- toYaml .Values.securityContext | nindent 12 }}
 {{- else }}
             privileged: {{ .Values.privileged }}

--- a/helm/provisioner/templates/daemonset_linux.yaml
+++ b/helm/provisioner/templates/daemonset_linux.yaml
@@ -69,7 +69,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- end }}
           securityContext:
-{{- if .Values.securityContext }}
+{{- if and .Values.securityContext (kindIs "map" .Values.securityContext) }}
 {{- if not (hasKey .Values.securityContext "privileged") }}
             privileged: {{ .Values.privileged }}
 {{- end }}

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -159,7 +159,20 @@ resources:
   #   memory: "32Mi"
   #   cpu: "10m"
 #
-# If set to false, containers created by the Provisioner Daemonset will run without extra privileges.
+# Security context for the provisioner container.
+# When set to a non-empty value, this takes precedence over the legacy
+# `privileged` field below.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+#
+# Example:
+#   securityContext:
+#     privileged: true
+#     allowPrivilegeEscalation: true
+securityContext: {}
+
+# If set to false, containers created by the Provisioner Daemonset will run
+# without extra privileges. This is the legacy field; when securityContext
+# above is non-empty, this field is ignored.
 privileged: true
 
 # Host PID set in the linux daemonset container spec. When set to true allows a pod to have access to the host process ID namespace

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -174,9 +174,9 @@ resources:
 #     allowPrivilegeEscalation: true
 securityContext: {}
 
-# If set to false, containers created by the Provisioner Daemonset will run
-# without extra privileges. This is the legacy field; when securityContext
-# above is non-empty, this field is ignored.
+# If set to false, the provisioner DaemonSet container will run without extra
+# privileges. This is the legacy field; when securityContext above is non-empty
+# and includes the `privileged` key, this field is ignored.
 privileged: true
 
 # Host PID set in the linux daemonset container spec. When set to true allows a pod to have access to the host process ID namespace

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -162,7 +162,7 @@ resources:
 # Security context for the Linux provisioner container.
 # This applies only to the Linux DaemonSet; the Windows DaemonSet does not
 # render a securityContext.
-# When set to a non-empty value, this takes precedence over the legacy
+# When set to a non-empty map/object value, this takes precedence over the legacy
 # `privileged` field below. However, if `securityContext` does not include
 # the `privileged` key, the legacy `privileged` value is automatically merged
 # to preserve backward compatibility.
@@ -175,8 +175,8 @@ resources:
 securityContext: {}
 
 # If set to false, the provisioner DaemonSet container will run without extra
-# privileges. This is the legacy field; when securityContext above is non-empty
-# and includes the `privileged` key, this field is ignored.
+# privileges. This is the legacy field; when securityContext above is a non-empty
+# map/object and includes the `privileged` key, this field is ignored.
 privileged: true
 
 # Host PID set in the linux daemonset container spec. When set to true allows a pod to have access to the host process ID namespace

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -159,7 +159,9 @@ resources:
   #   memory: "32Mi"
   #   cpu: "10m"
 #
-# Security context for the provisioner container.
+# Security context for the Linux provisioner container.
+# This applies only to the Linux DaemonSet; the Windows DaemonSet does not
+# render a securityContext.
 # When set to a non-empty value, this takes precedence over the legacy
 # `privileged` field below.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/helm/provisioner/values.yaml
+++ b/helm/provisioner/values.yaml
@@ -163,7 +163,9 @@ resources:
 # This applies only to the Linux DaemonSet; the Windows DaemonSet does not
 # render a securityContext.
 # When set to a non-empty value, this takes precedence over the legacy
-# `privileged` field below.
+# `privileged` field below. However, if `securityContext` does not include
+# the `privileged` key, the legacy `privileged` value is automatically merged
+# to preserve backward compatibility.
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 #
 # Example:


### PR DESCRIPTION
## What this PR does

Adds a new `securityContext` value to the Helm chart that allows users to specify the full container security context for the Linux provisioner container. When set to a non-empty value, it takes precedence over the legacy `privileged` field.

## Why

The DaemonSet template previously hardcoded the container securityContext to only expose the `privileged` field:

```yaml
securityContext:
  privileged: {{ .Values.privileged }}
```

In environments with admission controllers (e.g. Kyverno, OPA Gatekeeper) that enforce Pod Security Standards, this causes conflicts.

## Defaults

The default `securityContext` is **empty** (`{}`). When empty, the template falls back to the legacy `privileged` field (default: `true`). This means:

- **Existing users**: no behavior change — `privileged: true` still renders as before
- **Users who set `privileged: false`**: still works correctly via the fallback path
- **Users who set `securityContext`**: full control over the container security context

```yaml
# values.yaml defaults
securityContext: {}    # empty = use legacy privileged field
privileged: true       # legacy field, used as fallback
```

## Usage

```yaml
# Full securityContext control
securityContext:
  privileged: true
  allowPrivilegeEscalation: true
  capabilities:
    drop:
      - ALL
    add:
      - SYS_ADMIN
```

## Scope

This applies to the **Linux DaemonSet only**. The Windows DaemonSet does not render a securityContext.

## Changes

- `helm/provisioner/values.yaml`: Add `securityContext` field (default `{}`)
- `helm/provisioner/templates/daemonset_linux.yaml`: Use `securityContext` when non-empty, fall back to `privileged`

Related: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/555