### PR TITLE
docs(helm): add discovery directory documentation to Helm chart README

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -14,6 +14,7 @@ local-volume-provisioner in your Kubernetes with `helm install` directly.
     - [Generate yaml files with `helm template` and install with `kubectl`](#generate-yaml-files-with-helm-template-and-install-with-kubectl)
     - [Install using helm repo](#install-using-helm-repo)
     - [Install with `helm install` directly](#install-with-helm-install-directly)
+  - [Discovery Directory and Storage Classes](#discovery-directory-and-storage-classes)
   - [Configurations](#configurations)
   - [Examples](#examples)
 
@@ -110,6 +111,110 @@ helm upgrade --reset-value -f <path-to-your-values-file> <release-name> --namesp
 
 Please refer [helm docs](https://helm.sh/docs/intro/using_helm/) for more
 information.
+
+## Discovery Directory and Storage Classes
+
+The provisioner discovers local volumes by scanning **discovery directories** on
+each node. Each storage class maps to one discovery directory via the `hostDir`
+field in the `classes` list. The provisioner discovers:
+
+- **Mount points** for Filesystem mode volumes
+- **Symbolic links** to block devices (for Block mode volumes, or for
+  Filesystem mode when you want Kubernetes to format a raw device with `fsType`)
+
+For directory-based local volumes, they must be **bind-mounted** into the
+discovery directory.
+
+### Basic setup: one disk per PV
+
+Mount each disk into the discovery directory:
+
+```bash
+sudo mkfs.ext4 /dev/sdb
+DISK_UUID=$(sudo blkid -s UUID -o value /dev/sdb)
+sudo mkdir -p /mnt/disks/$DISK_UUID
+sudo mount -t ext4 /dev/sdb /mnt/disks/$DISK_UUID
+```
+
+Then configure the Helm values:
+
+```yaml
+classes:
+  - name: local-storage
+    hostDir: /mnt/disks
+    volumeMode: Filesystem
+    fsType: ext4
+    storageClass: true
+```
+
+### Sharing a disk filesystem by multiple PVs
+
+You can split a single disk into multiple PVs by creating subdirectories and
+bind-mounting them into the discovery directory. The provisioner discovers each
+bind mount as a separate PV.
+
+On the node:
+
+```bash
+# Format and mount the disk (NOT into the discovery directory)
+sudo mkfs.ext4 /dev/sdb
+DISK_UUID=$(sudo blkid -s UUID -o value /dev/sdb)
+sudo mkdir -p /mnt/$DISK_UUID
+sudo mount -t ext4 /dev/sdb /mnt/$DISK_UUID
+
+# Create subdirectories and bind-mount them into the discovery directory
+for i in $(seq 1 10); do
+  sudo mkdir -p /mnt/${DISK_UUID}/vol${i} /mnt/disks/${DISK_UUID}_vol${i}
+  sudo mount --bind /mnt/${DISK_UUID}/vol${i} /mnt/disks/${DISK_UUID}_vol${i}
+done
+```
+
+The Helm values are the same — `hostDir` points to the discovery directory:
+
+```yaml
+classes:
+  - name: local-storage
+    hostDir: /mnt/disks
+    volumeMode: Filesystem
+    fsType: ext4
+    storageClass: true
+```
+
+Each bind mount under `/mnt/disks` is discovered as a separate PV.
+
+### Block mode volumes
+
+For block devices, create symbolic links in the discovery directory using the
+stable device path:
+
+```bash
+sudo ln -s /dev/disk/by-id/<unique-disk-id> /mnt/disks/
+```
+
+```yaml
+classes:
+  - name: local-block
+    hostDir: /mnt/disks
+    volumeMode: Block
+    storageClass: true
+```
+
+### Key points
+
+- `hostDir` is the discovery directory path on the host node
+- **Discovery only scans the first level** of `hostDir` — it does not recurse
+  into subdirectories. All mount points, bind mounts, or symlinks must appear
+  directly under `hostDir`.
+- `mountDir` (optional) overrides the mount path inside the container; defaults
+  to the same value as `hostDir`
+- Each storage class must have its own unique discovery directory
+- Set `storageClass: true` (or configure it as a map) to have Helm create the
+  StorageClass object automatically; otherwise you must create it separately
+- **Mounts must be persistent across reboots.** Add entries to `/etc/fstab` for
+  all mounts and bind mounts. Without persistent mount entries, PV discovery
+  will be lost after a node restart.
+- See [operations.md](../docs/operations.md) for full details on preparing
+  local volumes
 
 ## Configurations
 


### PR DESCRIPTION
## What this PR does

Adds a new "Discovery Directory and Storage Classes" section to the Helm chart README that explains:

- What a discovery directory is and how it relates to the `hostDir` field
- How to configure the chart for a basic one-disk-per-PV setup
- How to share a disk across multiple PVs using bind mounts
- How to set up block mode volumes with symlinks
- Key points about `hostDir` vs `mountDir` and the requirement for unique directories per storage class

## Why

The [operations guide](../docs/operations.md) documents the concept of discovery directories and how to prepare local volumes on nodes. However, the Helm chart README makes no reference to this concept, leaving users unclear on how `classes[].hostDir` maps to the discovery directory pattern described in operations.md.

This is especially confusing for the "sharing a disk filesystem by multiple filesystem PVs" use case, where the node setup (bind mounts) and Helm configuration need to work together.

## Changes

- `helm/README.md`: Add "Discovery Directory and Storage Classes" section with examples

Related: https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/329