### PR TITLE
chore(deps): bump github/codeql-action init+analyze from 4.36.2 to 4.36.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4


### PR DESCRIPTION
**What this PR does / why we need it:**

Bumps [`github/codeql-action`](https://github.com/github/codeql-action) `init` **and** `analyze` from `4.36.2` (`8aad20d`) to `4.36.3` (`54f647b`) in a single commit.

Dependabot opened #577 (analyze) and #578 (init) as two independent PRs. Merging either one on its own leaves the two steps at mismatched versions, and CodeQL fails at the `analyze` step with:

```
Error: Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

`init` writes a config file tagged with its own version and `analyze` refuses to run when the two don't match. Both must be bumped together.

Closes #577.
Closes #578.

**Which issue(s) this PR fixes:**

Fixes the version-mismatch CodeQL failure hit when the two dependabot PRs land separately.

**Special notes for your reviewer:**

Same fix as kubernetes-csi/csi-driver-nfs#1186.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
