### PR TITLE
chore: bump Go version to 1.25.12 in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: 1.25.11
+          go-version: 1.25.12
       
       - name: Build an image from Dockerfile
         run: |


### PR DESCRIPTION
## What this PR does

Bumps the Go version from 1.25.11 to 1.25.12 in the trivy security scan workflow to fix the following vulnerabilities:

- **CVE-2026-39822**: Root escape via symlink plus trailing slash in os
- **CVE-2026-42505**: Invoking Encrypted Client Hello privacy leak in crypto/tls

Both are fixed in Go 1.25.12.

/kind cleanup