### PR TITLE
chore(deps): bump github/codeql-action init+analyze from 4.36.3 to 4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4


### PR DESCRIPTION
**What this PR does / why we need it:**

Bumps [`github/codeql-action`](https://github.com/github/codeql-action) `init` **and** `analyze` from `4.36.3` (`54f647b`) to `4.37.0` (`99df26d`) in a single commit.

Dependabot opened #581 and #582 bumping only one of the two steps. Merging either on its own leaves `init` and `analyze` at mismatched versions, and CodeQL fails at the `analyze` step with:

```
Error: Loaded a configuration file for version '4.36.3', but running version '4.37.0'
```

`init` writes a config file tagged with its own version and `analyze` refuses to run when the two don't match. Both must be bumped together.

Closes #581.
Closes #582.

**Special notes for your reviewer:**

Same fix as kubernetes-sigs/azuredisk-csi-driver#3686 and kubernetes-csi/csi-driver-nfs#1191.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```