### PR TITLE
fix(release): correct release branch regex in hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -141,8 +141,8 @@ if [ -z "$VERSION" ]; then
         echo "info: detecting version from PULL_BASE_REF '$PULL_BASE_REF'"
         if [[ "$PULL_BASE_REF" == "master" ]]; then
             VERSION=canary
-        elif [[ "$PULL_BASE_REF" =~ release-\d+ ]]; then
-            # release-2.0
+        elif [[ "$PULL_BASE_REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            # e.g. release-2.9 -> 2.9-canary
             VERSION=$(echo "$PULL_BASE_REF" | cut -f2 -d '-')-canary
         elif [[ "$PULL_BASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             # stable release: v1.2.3


### PR DESCRIPTION
**What this PR does / why we need it:**

The release-branch detection in `hack/release.sh` is currently:

```bash
elif [[ "$PULL_BASE_REF" =~ release-\d+ ]]; then
    # release-2.0
    VERSION=$(echo "$PULL_BASE_REF" | cut -f2 -d '-')-canary
```

This regex does not work in bash `[[ =~ ]]`:

- `\d` is not a valid character class in POSIX ERE (bash's regex engine); only PCRE understands `\d`.
- In an unquoted regex the backslash is also processed by the shell, so the pattern effectively becomes `release-d+` — one or more literal 'd's after 'release-'.

As a result any postsubmit run triggered by a push to a `release-*` branch (e.g. `PULL_BASE_REF=release-2.9`) falls through all three branches of the version-detection block and exits with:

```
+ [[ release-2.9 == \\m\\a\\s\\t\\e\\r ]]
+ [[ release-2.9 =~ release-d+ ]]
+ [[ release-2.9 =~ ^v[0-9]+\.[0-9]+... ]]
+ '[' -z '' ']'
error: failed to detect version
```

Hit today on the `post-sig-storage-local-static-provisioner-push-images` job for `release-2.9`:
https://console.cloud.google.com/cloud-build/builds/5fc2ad07-9f79-49fb-a1c1-0c85e96fd968?project=272675062337

**Fix:**

Replace `release-\d+` with an anchored POSIX ERE that matches the actual naming convention `release-<major>.<minor>` (e.g. `release-2.9`, `release-1.27`, `release-10.20`) and update the comment example accordingly.

Sanity check:

```
MATCH  release-2.9
MATCH  release-1.27
MATCH  release-10.20
no     master
no     v2.9.0
no     release-abc
no     release-
no     release-2
no     release-2.9-canary
```

Now a push to `release-2.9` will set `VERSION=2.9-canary` (with `ALLOW_UNSTABLE=yes`) and the postsubmit will produce `gcr.io/k8s-staging-sig-storage/local-volume-provisioner:2.9-canary` instead of failing.

Tag-driven builds (`PULL_BASE_REF=v2.9.0`) continue to hit the semver branch below and are unaffected.

**Which issue(s) this PR fixes:**

Fixes the `error: failed to detect version` failure on postsubmit runs triggered by pushes to `release-*` branches.

**Special notes for your reviewer:**

- `bash -n hack/release.sh` passes.
- No behavior change for `master` or tag-driven runs.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```