### PR TITLE
Cherry pick #599 into release-2.9: fix release branch regex in hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -141,8 +141,8 @@ if [ -z "$VERSION" ]; then
         echo "info: detecting version from PULL_BASE_REF '$PULL_BASE_REF'"
         if [[ "$PULL_BASE_REF" == "master" ]]; then
             VERSION=canary
-        elif [[ "$PULL_BASE_REF" =~ release-\d+ ]]; then
-            # release-2.0
+        elif [[ "$PULL_BASE_REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+            # e.g. release-2.9 -> 2.9-canary
             VERSION=$(echo "$PULL_BASE_REF" | cut -f2 -d '-')-canary
         elif [[ "$PULL_BASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             # stable release: v1.2.3


### PR DESCRIPTION
Cherry pick of #599 into `release-2.9`.

Without this fix any push to `release-2.9` triggers `post-sig-storage-local-static-provisioner-push-images` with `PULL_BASE_REF=release-2.9`, which falls through the broken `release-\d+` regex in `hack/release.sh` and fails with:

```
error: failed to detect version
```

(seen on https://console.cloud.google.com/cloud-build/builds/5fc2ad07-9f79-49fb-a1c1-0c85e96fd968?project=272675062337)

After this cherry-pick, subsequent `release-2.9` branch pushes will detect `VERSION=2.9-canary` and the postsubmit will publish `gcr.io/k8s-staging-sig-storage/local-volume-provisioner:2.9-canary` instead of failing. Tag-driven builds (`v2.9.0`) are unaffected either way.

/cherry-pick release-2.9

```release-note
NONE
```