### PR TITLE
ci: scan local-volume-node-cleanup image with trivy

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -17,19 +17,32 @@ jobs:
         with:
           go-version: 1.25.12
       
-      - name: Build an image from Dockerfile
+      - name: Build images from Dockerfile
         run: |
           export REGISTRY=test
           export DOCKER_CLI_EXPERIMENTAL=enabled
           export OUTPUT_TYPE=docker
           make build-container-linux-amd64
+          make build-node-cleanup-controller-linux-amd64
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner on local-volume-provisioner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db:2"
         with:
           image-ref: 'test/local-volume-provisioner:latest_linux_amd64'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+
+      - name: Run Trivy vulnerability scanner on local-volume-node-cleanup
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        env:
+          TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db:2"
+        with:
+          image-ref: 'test/local-volume-node-cleanup:latest_linux_amd64'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Extends the Trivy vulnerability-scan workflow to cover the `local-volume-node-cleanup` image alongside `local-volume-provisioner`. The Makefile already has a `build-node-cleanup-controller-linux-amd64` target that produces `${REGISTRY}/local-volume-node-cleanup:${STAGINGVERSION}_linux_amd64`, so with `REGISTRY=test` the image becomes `test/local-volume-node-cleanup:latest_linux_amd64` — same convention already used for the provisioner image in this workflow.

Changes:
- Rename the build step to reflect it now builds two images.
- Add `make build-node-cleanup-controller-linux-amd64` to the build step.
- Add a second Trivy step targeting `test/local-volume-node-cleanup:latest_linux_amd64`, using identical filter / severity / db config as the existing step.

**Which issue(s) this PR fixes**:

**Release note**:
```release-note
NONE
```
