### PR TITLE
chore: bump gcb-docker-gcloud to v20260729-0b834bafc6

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ timeout: 5400s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6
   entrypoint: hack/release.sh
   env:
   - REGISTRY=gcr.io/${_STAGING_PROJECT}


### PR DESCRIPTION
## What this PR does
- updates `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud` in `cloudbuild.yaml`
- bumps it from `v20260205-38cfa9523f` to `v20260729-0b834bafc6`

## Why
Pick up the current latest tagged `gcb-docker-gcloud` image.