### PR TITLE
chore: bump Go to 1.26.6

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.12
+          go-version: 1.26.6
       
       - name: Build images from Dockerfile
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/sig-storage-local-static-provisioner
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/golang/glog v1.2.5

--- a/pkg/util/fake_volume_util.go
+++ b/pkg/util/fake_volume_util.go
@@ -139,7 +139,7 @@ func (u *FakeVolumeUtil) getDirEntryCapacity(fullPath string, entryType string) 
 	for _, f := range files {
 		if file == f.Name {
 			if f.VolumeType != entryType {
-				return 0, fmt.Errorf("Directory entry %q is not a %q", f, entryType)
+				return 0, fmt.Errorf("Directory entry %q is not a %q", f.Name, entryType)
 			}
 			return f.Capacity, nil
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Bumps the Go version used by the trivy scan workflow from `1.25.12` to `1.26.6` and updates `go.mod` to `go 1.26.0` to pick up recent stdlib CVE fixes.

**Release note**:
```release-note
NONE
```